### PR TITLE
Update app.js

### DIFF
--- a/resources/themes/dusk/js/app.js
+++ b/resources/themes/dusk/js/app.js
@@ -1,13 +1,11 @@
 import "./bootstrap";
 import "./external/flowbite";
 
-import "swiper/css";
-import "swiper/css/pagination";
-
 import Alpine from "alpinejs";
 import Focus from "@alpinejs/focus";
 
-import Swiper, { Navigation, Pagination } from "swiper";
+import Swiper from "swiper";
+import { Navigation, Pagination } from "swiper/modules";
 import "swiper/css";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
@@ -15,11 +13,10 @@ import "swiper/css/pagination";
 Alpine.plugin(Focus);
 Alpine.start();
 
-Swiper.use([Navigation, Pagination]);
-
 // Swiper Initialization
 document.addEventListener("DOMContentLoaded", function () {
     const swiper = new Swiper(".swiper", {
+        modules: [Navigation, Pagination],
         // Your Swiper options here
         navigation: {
             nextEl: ".swiper-button-next",


### PR DESCRIPTION
Removed because duplicate (line 4-5 and 11-13).

Updated Swiper integration to match more like the current module-base API. The use of "Swiper.use()" and import named from "swiper" is not supported in newer versions.

Tested on Debian 12, Node 18, PHP 8.4