### PR TITLE
fix: make rcon package purchases atomic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ VITE_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 ## Custom variables
 RCON_HOST=127.0.0.1
 RCON_PORT=3001
+RCON_CONNECT_TIMEOUT=1
+RCON_READ_TIMEOUT=2
 
 # The emulator whose database schema this hotel runs on (see config/emulator.php)
 EMULATOR_DRIVER=arcturus

--- a/app/Actions/Shop/FulfillPackage.php
+++ b/app/Actions/Shop/FulfillPackage.php
@@ -2,10 +2,9 @@
 
 namespace App\Actions\Shop;
 
-use App\Actions\SendBadges;
-use App\Actions\SendCurrency;
-use App\Actions\SendFurniture;
-use App\Contracts\Rcon;
+use App\Emulator\Contracts\BadgeRepository;
+use App\Emulator\Contracts\CurrencyRepository;
+use App\Emulator\Contracts\FurnitureRepository;
 use App\Enums\CurrencyTypes;
 use App\Exceptions\ShopPurchaseException;
 use App\Models\Shop\WebsiteShopItem;
@@ -16,10 +15,9 @@ use RuntimeException;
 class FulfillPackage
 {
     public function __construct(
-        private readonly Rcon $rcon,
-        private readonly SendCurrency $sendCurrency,
-        private readonly SendFurniture $sendFurniture,
-        private readonly SendBadges $sendBadges,
+        private readonly CurrencyRepository $currencies,
+        private readonly FurnitureRepository $furniture,
+        private readonly BadgeRepository $badges,
     ) {}
 
     /**
@@ -32,14 +30,22 @@ class FulfillPackage
     {
         $package->loadMissing('items');
 
+        if ($package->items->isEmpty()) {
+            throw new ShopPurchaseException(__('This package is currently unavailable'));
+        }
+
         foreach ($package->items as $item) {
             $quantity = (int) $item->pivot->quantity;
+
+            if (! $item->is_active || $quantity < 1) {
+                throw self::misconfigured($item);
+            }
 
             match ($item->type) {
                 'currency' => $this->giveCurrency($user, $item, $quantity),
                 'furniture' => $this->giveFurniture($user, $item, $quantity),
-                'badge' => $this->sendBadges->execute($user, $item->type_value),
-                'rank' => $this->giveRank($user, (int) $item->type_value),
+                'badge' => $this->giveBadges($user, $item),
+                'rank' => $this->giveRank($user, $item),
                 default => throw self::misconfigured($item),
             };
         }
@@ -59,26 +65,42 @@ class FulfillPackage
             throw self::misconfigured($item);
         }
 
-        $this->sendCurrency->execute($user, $currency, (int) $amount * $quantity);
+        $this->currencies->give($user, $currency, (int) $amount * $quantity);
     }
 
     private function giveFurniture(User $user, WebsiteShopItem $item, int $quantity): void
     {
-        $this->sendFurniture->execute($user, [
-            ['item_id' => (int) $item->type_value, 'amount' => $quantity],
-        ]);
-    }
+        $baseItemId = (int) $item->type_value;
 
-    private function giveRank(User $user, int $rank): void
-    {
-        if (! $this->rcon->isConnected()) {
-            $user->update(['rank' => $rank]);
-
-            return;
+        if ($baseItemId <= 0) {
+            throw self::misconfigured($item);
         }
 
-        $this->rcon->setRank($user, $rank);
-        $this->rcon->disconnectUser($user);
+        $this->furniture->grant($user, $baseItemId, $quantity);
+    }
+
+    private function giveBadges(User $user, WebsiteShopItem $item): void
+    {
+        $codes = array_values(array_filter(array_map('trim', explode(';', $item->type_value))));
+
+        if ($codes === []) {
+            throw self::misconfigured($item);
+        }
+
+        foreach ($codes as $badge) {
+            $this->badges->grant($user, $badge);
+        }
+    }
+
+    private function giveRank(User $user, WebsiteShopItem $item): void
+    {
+        $rank = (int) $item->type_value;
+
+        if ($rank <= 0) {
+            throw self::misconfigured($item);
+        }
+
+        $user->update(['rank' => $rank]);
     }
 
     private static function misconfigured(WebsiteShopItem $item): ShopPurchaseException

--- a/app/Actions/Shop/PurchaseShopPackage.php
+++ b/app/Actions/Shop/PurchaseShopPackage.php
@@ -3,6 +3,7 @@
 namespace App\Actions\Shop;
 
 use App\Contracts\Rcon;
+use App\Exceptions\RconConnectionException;
 use App\Exceptions\ShopPurchaseException;
 use App\Models\Shop\WebsiteShopPackage;
 use App\Models\Shop\WebsiteShopPurchase;
@@ -27,6 +28,7 @@ class PurchaseShopPackage
         $recipient = $this->resolveRecipient($buyer, $package, $receiver);
 
         $this->ensurePurchasable($buyer, $recipient, $package);
+        $this->prepareRecipient($recipient);
 
         $this->fulfil($buyer, $recipient, $package);
 
@@ -49,6 +51,17 @@ class PurchaseShopPackage
 
     private function ensurePurchasable(User $buyer, User $recipient, WebsiteShopPackage $package): void
     {
+        $this->ensurePackageEligibility($recipient, $package, $buyer);
+
+        $this->ensureWithinPurchaseLimit($buyer, $package);
+
+        if ($buyer->website_balance < $package->priceInDollars()) {
+            throw new ShopPurchaseException($this->insufficientMessage($buyer, $package->priceInDollars()));
+        }
+    }
+
+    private function ensurePackageEligibility(User $recipient, WebsiteShopPackage $package, User $buyer): void
+    {
         if (! $package->isAvailable()) {
             throw new ShopPurchaseException(__('This package is no longer available'));
         }
@@ -64,47 +77,78 @@ class PurchaseShopPackage
                 ? __('Your rank is too high to purchase this package')
                 : __("The recipient's rank is too high to receive this package"));
         }
+    }
 
-        if (! $this->rcon->isConnected() && $recipient->online) {
+    private function prepareRecipient(User $recipient): void
+    {
+        if (! $recipient->online) {
+            return;
+        }
+
+        try {
+            // Arcturus currently reports HABBO_NOT_FOUND even after delivering
+            // alertuser, so this response is intentionally best-effort.
+            $this->rcon->sendCommand('alertuser', [
+                'user_id' => $recipient->id,
+                'message' => __('You are being disconnected so your package can be delivered safely. Please wait for the purchase to finish before reconnecting.'),
+            ]);
+
+            $this->rcon->sendCommand('disconnect', [
+                'user_id' => $recipient->id,
+                'username' => $recipient->username,
+            ]);
+        } catch (RconConnectionException) {
             throw new ShopPurchaseException(__('Please logout before purchasing a package'));
         }
 
-        $this->ensureWithinPurchaseLimit($buyer, $package);
-
-        if ($buyer->website_balance < $package->priceInDollars()) {
-            throw new ShopPurchaseException($this->insufficientMessage($buyer, $package->priceInDollars()));
+        if ($recipient->refresh()->online) {
+            throw new ShopPurchaseException(__('Please logout before purchasing a package'));
         }
     }
 
     /**
-     * Charge, decrement stock and deliver atomically. The limit and stock are
-     * re-checked under the buyer's row lock so concurrent requests cannot
-     * exceed either.
+     * Deliver, decrement stock and charge in one transaction. The buyer,
+     * recipient and package locks serialize balance, limit and stock checks.
      */
     private function fulfil(User $buyer, User $recipient, WebsiteShopPackage $package): void
     {
-        $price = $package->priceInDollars();
-
-        DB::transaction(function () use ($buyer, $recipient, $package, $price): void {
+        DB::transaction(function () use ($buyer, $recipient, $package): void {
             $locked = $this->lockUsers($buyer, $recipient);
             $lockedBuyer = $locked->get($buyer->id);
             $lockedRecipient = $locked->get($recipient->id);
+            $lockedPackage = WebsiteShopPackage::whereKey($package->id)->lockForUpdate()->first();
 
-            if (! $lockedBuyer || ! $lockedRecipient || $lockedBuyer->website_balance < $price) {
-                throw new ShopPurchaseException($this->insufficientMessage($lockedBuyer ?? $buyer, $price));
+            if (! $lockedBuyer || ! $lockedRecipient) {
+                throw new ShopPurchaseException(__('The buyer or recipient is no longer available'));
             }
 
-            $this->ensureWithinPurchaseLimit($lockedBuyer, $package);
+            if (! $lockedPackage) {
+                throw new ShopPurchaseException(__('This package is no longer available'));
+            }
+
+            $price = $lockedPackage->priceInDollars();
+
+            if ($lockedBuyer->website_balance < $price) {
+                throw new ShopPurchaseException($this->insufficientMessage($lockedBuyer, $price));
+            }
+
+            if ($lockedRecipient->online) {
+                throw new ShopPurchaseException(__('Please logout before purchasing a package'));
+            }
+
+            $this->ensurePackageEligibility($lockedRecipient, $lockedPackage, $lockedBuyer);
+            $this->ensureWithinPurchaseLimit($lockedBuyer, $lockedPackage);
+
+            $lockedPackage->load('items');
+            $this->fulfillPackage->execute($lockedRecipient, $lockedPackage);
+
+            $this->takeStock($lockedPackage);
 
             $lockedBuyer->decrement('website_balance', $price);
 
-            $this->takeStock($package);
-
-            $this->fulfillPackage->execute($lockedRecipient, $package);
-
             WebsiteShopPurchase::create([
                 'user_id' => $lockedBuyer->id,
-                'website_shop_package_id' => $package->id,
+                'website_shop_package_id' => $lockedPackage->id,
                 'gifted_to' => $lockedRecipient->is($lockedBuyer) ? null : $lockedRecipient->id,
             ]);
         });
@@ -136,13 +180,11 @@ class PurchaseShopPackage
             return;
         }
 
-        $taken = WebsiteShopPackage::whereKey($package->id)
-            ->where('stock', '>', 0)
-            ->decrement('stock');
-
-        if ($taken === 0) {
+        if ($package->stock <= 0) {
             throw new ShopPurchaseException(__('This package is out of stock'));
         }
+
+        $package->decrement('stock');
     }
 
     /**

--- a/app/Contracts/Rcon.php
+++ b/app/Contracts/Rcon.php
@@ -2,6 +2,7 @@
 
 namespace App\Contracts;
 
+use App\Data\RconResponse;
 use App\Enums\CurrencyTypes;
 use App\Models\User;
 
@@ -16,7 +17,7 @@ interface Rcon
     /**
      * @param  array<string, mixed>|null  $data
      */
-    public function sendCommand(string $command, ?array $data = null): bool;
+    public function sendCommand(string $command, ?array $data = null): RconResponse;
 
     public function sendGift(User $user, int $itemId, string $message = 'Here is a gift.'): void;
 

--- a/app/Data/RconResponse.php
+++ b/app/Data/RconResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Data;
+
+final readonly class RconResponse
+{
+    public function __construct(
+        public int $status,
+        public string $message,
+    ) {}
+
+    public function successful(): bool
+    {
+        return $this->status === 0;
+    }
+}

--- a/app/Services/AfterCommitRcon.php
+++ b/app/Services/AfterCommitRcon.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Contracts\Rcon;
+use App\Data\RconResponse;
 use App\Enums\CurrencyTypes;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
@@ -22,16 +23,14 @@ class AfterCommitRcon implements Rcon
     }
 
     /**
-     * The send is deferred, so the returned bool reflects the connection
-     * state now rather than the eventual write result.
+     * Low-level commands are request-response operations and therefore execute
+     * immediately. Typed convenience commands remain deferred until commit.
      *
      * @param  array<string, mixed>|null  $data
      */
-    public function sendCommand(string $command, ?array $data = null): bool
+    public function sendCommand(string $command, ?array $data = null): RconResponse
     {
-        $this->defer(fn () => $this->inner->sendCommand($command, $data));
-
-        return $this->inner->isConnected();
+        return $this->inner->sendCommand($command, $data);
     }
 
     public function sendGift(User $user, int $itemId, string $message = 'Here is a gift.'): void

--- a/app/Services/FakeRcon.php
+++ b/app/Services/FakeRcon.php
@@ -3,7 +3,9 @@
 namespace App\Services;
 
 use App\Contracts\Rcon;
+use App\Data\RconResponse;
 use App\Enums\CurrencyTypes;
+use App\Exceptions\RconConnectionException;
 use App\Models\User;
 
 /**
@@ -18,11 +20,21 @@ class FakeRcon implements Rcon
      */
     public array $calls = [];
 
+    /** @var list<RconResponse> */
+    private array $responses = [];
+
     public function __construct(private bool $connected = false) {}
 
     public function connected(bool $connected = true): self
     {
         $this->connected = $connected;
+
+        return $this;
+    }
+
+    public function respondWith(RconResponse ...$responses): self
+    {
+        array_push($this->responses, ...$responses);
 
         return $this;
     }
@@ -35,9 +47,21 @@ class FakeRcon implements Rcon
     /**
      * @param  array<string, mixed>|null  $data
      */
-    public function sendCommand(string $command, ?array $data = null): bool
+    public function sendCommand(string $command, ?array $data = null): RconResponse
     {
-        return $this->record(__FUNCTION__, ['command' => $command, 'data' => $data]);
+        $this->record(__FUNCTION__, ['command' => $command, 'data' => $data]);
+
+        if (! $this->connected) {
+            throw new RconConnectionException('Unable to connect to fake RCON');
+        }
+
+        $response = array_shift($this->responses) ?? new RconResponse(0, 'OK');
+
+        if ($command === 'disconnect' && $response->successful() && isset($data['user_id'])) {
+            User::whereKey((int) $data['user_id'])->update(['online' => '0']);
+        }
+
+        return $response;
     }
 
     public function sendGift(User $user, int $itemId, string $message = 'Here is a gift.'): void
@@ -98,10 +122,8 @@ class FakeRcon implements Rcon
     /**
      * @param  array<string, mixed>  $args
      */
-    private function record(string $method, array $args): bool
+    private function record(string $method, array $args): void
     {
         $this->calls[] = ['method' => $method, 'args' => $args];
-
-        return $this->connected;
     }
 }

--- a/app/Services/RconService.php
+++ b/app/Services/RconService.php
@@ -3,98 +3,173 @@
 namespace App\Services;
 
 use App\Contracts\Rcon;
+use App\Data\RconResponse;
 use App\Enums\CurrencyTypes;
+use App\Exceptions\RconConnectionException;
 use App\Models\User;
 use Illuminate\Support\Facades\Log;
-use Socket;
+use JsonException;
 
 class RconService implements Rcon
 {
-    protected ?Socket $socket = null;
-
-    protected bool $isConnected = false;
-
-    /**
-     * @var array{ip: mixed, port: int}
-     */
-    protected array $config;
-
-    public function __construct()
-    {
-        $this->config = [
-            'ip' => setting('rcon_ip'),
-            'port' => (int) setting('rcon_port'),
-        ];
-
-        $this->initialize();
-    }
-
-    private function initialize(): void
-    {
-        $socket = @socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
-
-        if ($socket === false) {
-            Log::error('RCON initialization failed: ' . socket_strerror(socket_last_error()));
-
-            $this->closeConnection();
-
-            return;
-        }
-
-        $this->socket = $socket;
-
-        if (! @socket_connect($this->socket, $this->config['ip'], $this->config['port'])) {
-            Log::error('RCON connection failed: ' . socket_strerror(socket_last_error()));
-
-            $this->closeConnection();
-
-            return;
-        }
-
-        $this->isConnected = true;
-    }
-
-    private function closeConnection(): void
-    {
-        if ($this->socket) {
-            socket_close($this->socket);
-        }
-
-        $this->socket = null;
-        $this->isConnected = false;
-    }
+    public function __construct(
+        private readonly ?string $host = null,
+        private readonly ?int $port = null,
+    ) {}
 
     public function isConnected(): bool
     {
-        return $this->isConnected;
+        try {
+            $socket = $this->connect();
+            fclose($socket);
+
+            return true;
+        } catch (RconConnectionException) {
+            return false;
+        }
     }
 
-    public function sendCommand(string $command, ?array $data = null): bool
+    public function sendCommand(string $command, ?array $data = null): RconResponse
     {
-        if (! $this->isConnected) {
-            Log::error('RCON command failed: Not connected');
-
-            $this->closeConnection();
-
-            return false;
-        }
-
         $payload = json_encode(['key' => $command, 'data' => $data], JSON_THROW_ON_ERROR);
+        $socket = $this->connect();
 
-        if (! @socket_write($this->socket, $payload, strlen($payload))) {
-            Log::error("RCON command ($command) failed: " . socket_strerror(socket_last_error($this->socket)));
+        try {
+            $this->write($socket, $payload);
+            stream_socket_shutdown($socket, STREAM_SHUT_WR);
 
-            $this->closeConnection();
+            $response = stream_get_contents($socket);
+            $metadata = stream_get_meta_data($socket);
 
-            return false;
+            if ($metadata['timed_out']) {
+                throw new RconConnectionException("RCON command '{$command}' timed out waiting for a response");
+            }
+
+            if ($response === false || trim($response) === '') {
+                throw new RconConnectionException("RCON command '{$command}' returned an empty response");
+            }
+
+            return $this->parseResponse($command, $response);
+        } finally {
+            fclose($socket);
+        }
+    }
+
+    /**
+     * Arcturus accepts one JSON request per TCP connection and closes the
+     * connection after writing its response.
+     *
+     * @return resource
+     */
+    private function connect()
+    {
+        $errorCode = 0;
+        $errorMessage = '';
+        $timeout = max(0.1, (float) config('habbo.rcon.connect_timeout_seconds', 1));
+        $socket = @stream_socket_client(
+            $this->endpoint(),
+            $errorCode,
+            $errorMessage,
+            $timeout,
+            STREAM_CLIENT_CONNECT,
+        );
+
+        if ($socket === false) {
+            throw new RconConnectionException("Unable to connect to RCON: {$errorMessage} ({$errorCode})");
         }
 
-        return true;
+        $readTimeout = max(0.1, (float) config('habbo.rcon.read_timeout_seconds', 2));
+        $seconds = (int) $readTimeout;
+        $microseconds = (int) (($readTimeout - $seconds) * 1_000_000);
+        stream_set_timeout($socket, $seconds, $microseconds);
+
+        return $socket;
+    }
+
+    private function endpoint(): string
+    {
+        $host = trim($this->host ?? (string) setting('rcon_ip'));
+        $port = $this->port ?? (int) setting('rcon_port');
+
+        if ($host === '' || $port < 1 || $port > 65535) {
+            throw new RconConnectionException('RCON host or port is not configured correctly');
+        }
+
+        $formattedHost = str_contains($host, ':') && ! str_starts_with($host, '[')
+            ? "[{$host}]"
+            : $host;
+
+        return "tcp://{$formattedHost}:{$port}";
+    }
+
+    /**
+     * @param  resource  $socket
+     */
+    private function write($socket, string $payload): void
+    {
+        $written = 0;
+        $length = strlen($payload);
+
+        while ($written < $length) {
+            $bytes = fwrite($socket, substr($payload, $written));
+
+            if ($bytes === false || $bytes === 0) {
+                throw new RconConnectionException('RCON connection closed before the command was fully written');
+            }
+
+            $written += $bytes;
+        }
+    }
+
+    private function parseResponse(string $command, string $response): RconResponse
+    {
+        try {
+            $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RconConnectionException("RCON command '{$command}' returned malformed JSON", previous: $exception);
+        }
+
+        if (
+            ! is_array($decoded)
+            || ! isset($decoded['status'], $decoded['message'])
+            || ! is_int($decoded['status'])
+            || ! is_string($decoded['message'])
+        ) {
+            throw new RconConnectionException("RCON command '{$command}' returned an invalid response");
+        }
+
+        return new RconResponse($decoded['status'], $decoded['message']);
+    }
+
+    /**
+     * Typed RCON helpers are fire-and-forget operations. Preserve that contract
+     * while retaining transport and emulator failures in the application log.
+     *
+     * @param  array<string, mixed>|null  $data
+     */
+    private function dispatchCommand(string $command, ?array $data = null): void
+    {
+        try {
+            $response = $this->sendCommand($command, $data);
+
+            if (! $response->successful()) {
+                Log::warning('RCON command was rejected by the emulator', [
+                    'command' => $command,
+                    'status' => $response->status,
+                    'message' => $response->message,
+                ]);
+            }
+        } catch (RconConnectionException $exception) {
+            Log::error('RCON command failed', [
+                'command' => $command,
+                'message' => $exception->getMessage(),
+            ]);
+        }
     }
 
     public function sendGift(User $user, int $itemId, string $message = 'Here is a gift.'): void
     {
-        $this->sendCommand('sendgift', [
+        $this->dispatchCommand('sendgift', [
             'user_id' => $user->id,
             'itemid' => $itemId,
             'message' => $message,
@@ -104,7 +179,7 @@ class RconService implements Rcon
     public function giveCurrency(User $user, CurrencyTypes $currency, int $amount): void
     {
         if ($currency === CurrencyTypes::Credits) {
-            $this->sendCommand('givecredits', [
+            $this->dispatchCommand('givecredits', [
                 'user_id' => $user->id,
                 'credits' => $amount,
             ]);
@@ -112,7 +187,7 @@ class RconService implements Rcon
             return;
         }
 
-        $this->sendCommand('givepoints', [
+        $this->dispatchCommand('givepoints', [
             'user_id' => $user->id,
             'points' => $amount,
             'type' => $currency,
@@ -121,7 +196,7 @@ class RconService implements Rcon
 
     public function giveBadge(User $user, string $badge): void
     {
-        $this->sendCommand('givebadge', [
+        $this->dispatchCommand('givebadge', [
             'user_id' => $user->id,
             'badge' => $badge,
         ]);
@@ -129,7 +204,7 @@ class RconService implements Rcon
 
     public function setMotto(User $user, string $motto): void
     {
-        $this->sendCommand('setmotto', [
+        $this->dispatchCommand('setmotto', [
             'user_id' => $user->id,
             'motto' => $motto,
         ]);
@@ -137,12 +212,12 @@ class RconService implements Rcon
 
     public function updateWordFilter(): void
     {
-        $this->sendCommand('updatewordfilter');
+        $this->dispatchCommand('updatewordfilter');
     }
 
     public function disconnectUser(User $user): void
     {
-        $this->sendCommand('disconnect', [
+        $this->dispatchCommand('disconnect', [
             'user_id' => $user->id,
             'username' => $user->username,
         ]);
@@ -150,7 +225,7 @@ class RconService implements Rcon
 
     public function setRank(User $user, int $rank): void
     {
-        $this->sendCommand('setrank', [
+        $this->dispatchCommand('setrank', [
             'user_id' => $user->id,
             'rank' => $rank,
         ]);
@@ -158,12 +233,12 @@ class RconService implements Rcon
 
     public function updateCatalog(): void
     {
-        $this->sendCommand('updatecatalog');
+        $this->dispatchCommand('updatecatalog');
     }
 
     public function alertUser(User $user, string $message): void
     {
-        $this->sendCommand('alertuser', [
+        $this->dispatchCommand('alertuser', [
             'user_id' => $user->id,
             'message' => $message,
         ]);
@@ -171,7 +246,7 @@ class RconService implements Rcon
 
     public function forwardUser(User $user, int $roomId): void
     {
-        $this->sendCommand('forwarduser', [
+        $this->dispatchCommand('forwarduser', [
             'user_id' => $user->id,
             'room_id' => $roomId,
         ]);
@@ -179,7 +254,7 @@ class RconService implements Rcon
 
     public function updateConfig(User $user, string $command): void
     {
-        $this->sendCommand('executecommand', [
+        $this->dispatchCommand('executecommand', [
             'user_id' => $user->id,
             'command' => $command,
         ]);

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "license": "MIT",
     "require": {
         "php": "^8.5",
-        "ext-sockets": "*",
         "doctrine/dbal": "^3.5",
         "filament/filament": "^5.0",
         "flowframe/laravel-trend": "^0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84dee998e19a29767e558363351f577b",
+    "content-hash": "1a114c693a97b9d2e194116e0e8a170e",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -14960,8 +14960,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.5",
-        "ext-sockets": "*"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/config/habbo.php
+++ b/config/habbo.php
@@ -36,9 +36,8 @@ return [
     ],
 
     'rcon' => [
-        'domain' => AF_INET,
-        'type' => SOCK_STREAM,
-        'protocol' => SOL_TCP,
+        'connect_timeout_seconds' => (float) env('RCON_CONNECT_TIMEOUT', 1),
+        'read_timeout_seconds' => (float) env('RCON_READ_TIMEOUT', 2),
     ],
 
     'client' => [

--- a/tests/Feature/Rcon/RconServiceTest.php
+++ b/tests/Feature/Rcon/RconServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Services\RconService;
+
+test('rcon follows the arcturus one-command-per-connection protocol', function () {
+    $errorCode = 0;
+    $errorMessage = '';
+    $server = stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+
+    expect($server)->not->toBeFalse();
+
+    $address = stream_socket_get_name($server, false);
+    $port = (int) substr((string) $address, strrpos((string) $address, ':') + 1);
+    $script = <<<'PHP'
+    $server = fopen('php://fd/3', 'r+');
+    $commands = ['first', 'second'];
+    $valid = true;
+
+    foreach ($commands as $index => $expectedCommand) {
+        $connection = stream_socket_accept($server, 5);
+
+        if ($connection === false) {
+            exit(1);
+        }
+
+        $request = json_decode((string) stream_get_contents($connection), true);
+        $valid = $valid
+            && $request === ['key' => $expectedCommand, 'data' => ['sequence' => $index + 1]];
+
+        $response = json_encode([
+            'status' => $valid ? 0 : 1,
+            'message' => "response-{$index}",
+        ], JSON_THROW_ON_ERROR);
+        $middle = intdiv(strlen($response), 2);
+
+        fwrite($connection, substr($response, 0, $middle));
+        usleep(10_000);
+        fwrite($connection, substr($response, $middle));
+        fclose($connection);
+    }
+
+    fclose($server);
+    exit($valid ? 0 : 1);
+    PHP;
+    $process = proc_open(
+        [PHP_BINARY, '-r', $script],
+        [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+            3 => $server,
+        ],
+        $pipes,
+    );
+
+    expect($process)->not->toBeFalse();
+
+    fclose($server);
+    fclose($pipes[0]);
+
+    try {
+        $rcon = new RconService('127.0.0.1', $port);
+        $first = $rcon->sendCommand('first', ['sequence' => 1]);
+        $second = $rcon->sendCommand('second', ['sequence' => 2]);
+    } finally {
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+    }
+
+    expect($first->successful())->toBeTrue()
+        ->and($first->message)->toBe('response-0')
+        ->and($second->successful())->toBeTrue()
+        ->and($second->message)->toBe('response-1')
+        ->and($exitCode)->toBe(0, $stderr ?: $stdout);
+});

--- a/tests/Feature/Shop/ShopPackageTest.php
+++ b/tests/Feature/Shop/ShopPackageTest.php
@@ -1,9 +1,14 @@
 <?php
 
+use App\Actions\Shop\PurchaseShopPackage;
+use App\Data\RconResponse;
+use App\Emulator\Contracts\CurrencyRepository;
+use App\Enums\CurrencyTypes;
 use App\Models\Shop\WebsiteShopItem;
 use App\Models\Shop\WebsiteShopPackage;
 use App\Models\Shop\WebsiteShopPurchase;
 use App\Models\User;
+use Illuminate\Support\Collection;
 
 function makePackage(array $attributes = []): WebsiteShopPackage
 {
@@ -125,4 +130,91 @@ test('a gifted package delivers to the recipient and records the gift', function
     expect((float) $buyer->refresh()->website_balance)->toBe(95.0)
         ->and((int) $recipient->refresh()->credits)->toBe($recipientCredits + 200)
         ->and(WebsiteShopPurchase::where('user_id', $buyer->id)->where('gifted_to', $recipient->id)->count())->toBe(1);
+});
+
+test('an online recipient is disconnected before atomic delivery', function () {
+    installHotel();
+
+    $user = User::factory()->create(['website_balance' => 20, 'online' => '1'])->refresh();
+    $package = makePackage();
+    $startCredits = (int) $user->credits;
+    $this->rcon->connected();
+
+    $this->actingAs($user)
+        ->post(route('shop.buy-package', $package), [])
+        ->assertSessionHas('success');
+
+    expect($user->refresh()->online)->toBeFalse()
+        ->and((float) $user->website_balance)->toBe(15.0)
+        ->and((int) $user->credits)->toBe($startCredits + 200)
+        ->and(array_column($this->rcon->calls, 'method'))->toBe(['sendCommand', 'sendCommand'])
+        ->and($this->rcon->calls[0]['args']['command'])->toBe('alertuser')
+        ->and($this->rcon->calls[1]['args']['command'])->toBe('disconnect');
+});
+
+test('a failed online disconnect leaves balances and goods untouched', function () {
+    installHotel();
+
+    $user = User::factory()->create(['website_balance' => 20, 'online' => '1'])->refresh();
+    $package = makePackage();
+    $startCredits = (int) $user->credits;
+    $this->rcon->connected()->respondWith(
+        new RconResponse(2, 'Arcturus alert response'),
+        new RconResponse(1, 'Unable to disconnect user'),
+    );
+
+    $this->actingAs($user)
+        ->post(route('shop.buy-package', $package), [])
+        ->assertSessionHasErrors('message');
+
+    expect($user->refresh()->online)->toBeTrue()
+        ->and((float) $user->website_balance)->toBe(20.0)
+        ->and((int) $user->credits)->toBe($startCredits)
+        ->and(WebsiteShopPurchase::count())->toBe(0);
+});
+
+test('a fulfillment failure rolls back goods stock charge and history', function () {
+    installHotel();
+
+    $user = User::factory()->create(['website_balance' => 20]);
+    $package = makePackage(['stock' => 1]);
+    $startCredits = (int) $user->credits;
+    $currencies = app(CurrencyRepository::class);
+
+    $failingCurrencies = new class($currencies) implements CurrencyRepository
+    {
+        public function __construct(private readonly CurrencyRepository $inner) {}
+
+        public function balance(User $user, CurrencyTypes $currency): int
+        {
+            return $this->inner->balance($user, $currency);
+        }
+
+        public function give(User $user, CurrencyTypes $currency, int $amount): void
+        {
+            $this->inner->give($user, $currency, $amount);
+
+            throw new RuntimeException('Simulated fulfillment failure');
+        }
+
+        public function deduct(User $user, CurrencyTypes $currency, int $amount): bool
+        {
+            return $this->inner->deduct($user, $currency, $amount);
+        }
+
+        public function topBy(CurrencyTypes $currency, int $limit, array $excludeUserIds = []): Collection
+        {
+            return $this->inner->topBy($currency, $limit, $excludeUserIds);
+        }
+    };
+
+    $this->app->instance(CurrencyRepository::class, $failingCurrencies);
+
+    expect(fn () => app(PurchaseShopPackage::class)->execute($user, $package, null))
+        ->toThrow(RuntimeException::class, 'Simulated fulfillment failure');
+
+    expect((float) $user->refresh()->website_balance)->toBe(20.0)
+        ->and((int) $user->credits)->toBe($startCredits)
+        ->and($package->refresh()->stock)->toBe(1)
+        ->and(WebsiteShopPurchase::count())->toBe(0);
 });


### PR DESCRIPTION
## Summary

- align RCON transport with the Arcturus one-command-per-connection protocol
- parse emulator responses and distinguish transport failures from command failures
- disconnect online recipients before delivery and verify the persisted online state
- grant package goods, decrement stock, charge balance, and record history in one database transaction
- remove the no-longer-needed ext-sockets platform requirement

## Arcturus audit

Arcturus reads one JSON request, writes a JSON status and message response, and closes the connection. It has no compensating RCON commands for reversing furniture or badge grants. Package delivery therefore uses the emulator repositories after a synchronous disconnect, allowing all goods and payment mutations to roll back together in MariaDB.

The alertuser response remains best effort because Arcturus reports HABBO_NOT_FOUND after delivering the alert. The disconnect result is verified through the persisted users.online state before any package mutation begins.

## Verification

- vendor/bin/pest tests/Feature/Shop/ShopPackageTest.php tests/Feature/Rcon/AfterCommitRconTest.php tests/Feature/Rcon/RconServiceTest.php --compact
- vendor/bin/phpstan analyse --no-progress --memory-limit=1G
- vendor/bin/pint on all changed PHP files
- composer validate --strict
- composer install --dry-run --no-interaction
- composer audit --no-interaction
- git diff --check