### PR TITLE
fix: secure badge assets and external text writes

### DIFF
--- a/app/Filament/Pages/BadgePage.php
+++ b/app/Filament/Pages/BadgePage.php
@@ -3,7 +3,10 @@
 namespace App\Filament\Pages;
 
 use App\Filament\Traits\TranslatableResource;
+use App\Rules\ValidBadgeCode;
+use App\Services\Badge\BadgeImageStorage;
 use App\Services\Parsers\ExternalTextsParser;
+use App\Support\BadgeCode;
 use Filament\Actions\Action;
 use Filament\Actions\Action as PageAction;
 use Filament\Actions\ActionGroup;
@@ -16,8 +19,8 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 use Throwable;
 
 class BadgePage extends Page
@@ -59,8 +62,11 @@ class BadgePage extends Page
                         TextInput::make('code')
                             ->label(__('filament::resources.inputs.badge_code'))
                             ->helperText(__('filament::resources.helpers.badge_code_helper'))
+                            ->required()
+                            ->maxLength(32)
+                            ->rules([new ValidBadgeCode])
                             ->afterStateUpdated(function (?string $state, Set $set) {
-                                $set('code', strtoupper($state));
+                                $set('code', strtoupper((string) $state));
                             })
                             ->suffixAction(fn (): PageAction => PageAction::make('search')->icon('heroicon-o-magnifying-glass')->action(fn () => $this->searchBadgesByCode()),
                             ),
@@ -68,6 +74,8 @@ class BadgePage extends Page
                         TextInput::make('image')
                             ->label(__('filament::resources.inputs.badge_image'))
                             ->placeholder('...')
+                            ->url()
+                            ->maxLength(2048)
                             ->autocomplete()
                             ->visible(fn (Get $get) => isset($this->data['image']) ?? false)
                             ->prefixAction(
@@ -86,11 +94,13 @@ class BadgePage extends Page
                     ->schema([
                         TextInput::make('nitro.title')
                             ->label(__('filament::resources.inputs.badge_title'))
+                            ->maxLength(100)
                             ->placeholder('...')
                             ->visible(fn () => isset($this->data['nitro']['title']) ?? false),
 
                         TextInput::make('nitro.description')
                             ->label(__('filament::resources.inputs.badge_description'))
+                            ->maxLength(255)
                             ->placeholder('...')
                             ->visible(fn () => isset($this->data['nitro']['description']) ?? false),
                     ]),
@@ -101,11 +111,13 @@ class BadgePage extends Page
                     ->schema([
                         TextInput::make('flash.title')
                             ->label(__('filament::resources.inputs.badge_title'))
+                            ->maxLength(100)
                             ->placeholder('...')
                             ->visible(fn () => isset($this->data['flash']['title']) ?? false),
 
                         TextInput::make('flash.description')
                             ->label(__('filament::resources.inputs.badge_description'))
+                            ->maxLength(255)
                             ->placeholder('...')
                             ->visible(fn () => isset($this->data['flash']['description']) ?? false),
                     ]),
@@ -115,7 +127,7 @@ class BadgePage extends Page
 
     private function searchBadgesByCode(): void
     {
-        $badgeCode = $this->form->getState()['code'] ?? null;
+        $badgeCode = BadgeCode::normalize((string) ($this->form->getState()['code'] ?? ''));
 
         if (empty($badgeCode)) {
             $this->notify('danger', __('filament::resources.notifications.badge_code_required'));
@@ -181,8 +193,10 @@ class BadgePage extends Page
         ];
     }
 
-    public function create()
+    public function create(): void
     {
+        $this->data = $this->form->getState();
+
         $nitroEnabled = config('hotel.client.nitro.enabled');
         $flashEnabled = config('hotel.client.flash.enabled');
 
@@ -216,7 +230,8 @@ class BadgePage extends Page
         }
 
         try {
-            $this->uploadBadgeImage($externalTextsParser);
+            $this->data['code'] = BadgeCode::normalize((string) $this->data['code']);
+            $this->uploadBadgeImage($externalTextsParser, app(BadgeImageStorage::class));
 
             if (! empty($this->data['nitro']) && $nitroEnabled) {
                 $externalTextsParser->updateNitroBadgeTexts($this->data['code'], ...$this->data['nitro']);
@@ -225,7 +240,10 @@ class BadgePage extends Page
                 $externalTextsParser->updateFlashBadgeTexts($this->data['code'], ...$this->data['flash']);
             }
         } catch (Throwable $exception) {
-            Log::channel('badge')->error('[ORION BADGE RESOURCE] - ERROR: ' . $exception->getMessage());
+            Log::channel('badge')->error('Badge update failed', [
+                'badge_code' => $this->data['code'] ?? null,
+                'exception' => $exception,
+            ]);
 
             Notification::make()
                 ->icon('heroicon-o-exclamation-triangle')
@@ -248,49 +266,21 @@ class BadgePage extends Page
             ->send();
     }
 
-    protected function uploadBadgeImage(ExternalTextsParser $parser): void
+    protected function uploadBadgeImage(ExternalTextsParser $parser, BadgeImageStorage $images): void
     {
-        if (empty($this->data['image']) || ! filter_var($this->data['image'], FILTER_VALIDATE_URL)) {
+        if (empty($this->data['image'])) {
             return;
         }
 
-        if ($this->data['image'] == $parser->getBadgeImageUrl($this->data['code'])) {
+        if (! filter_var($this->data['image'], FILTER_VALIDATE_URL)) {
+            throw new RuntimeException('The badge image URL is invalid.');
+        }
+
+        if ($this->data['image'] === $parser->getBadgeImageUrl($this->data['code'])) {
             return;
         }
 
-        $image = Http::get($this->data['image']);
-
-        if (! $image->successful()) {
-            return;
-        }
-
-        $contentType = $image->header('content-type');
-
-        $gdImage = match ($contentType) {
-            'image/png' => imagecreatefrompng($this->data['image']),
-            'image/gif' => imagecreatefromgif($this->data['image']),
-            'image/jpeg' => imagecreatefromjpeg($this->data['image']),
-            default => false
-        };
-
-        if ($gdImage === false) {
-            Notification::make()
-                ->icon('heroicon-o-exclamation-triangle')
-                ->iconColor('danger')
-                ->color('danger')
-                ->title(__('filament::resources.notifications.badge_image_upload_failed'))
-                ->send();
-
-            return;
-        }
-
-        $uploadPath = public_path(sprintf('%s%s%s.gif',
-            rtrim(config('hotel.client.flash.relative_files_path'), '\//'),
-            '/c_images/album1584/',
-            $this->data['code'],
-        ));
-
-        imagegif($gdImage, $uploadPath);
+        $images->storeRemote($this->data['code'], $this->data['image']);
     }
 
     /**

--- a/app/Filament/Resources/Hotel/BadgeUploads/BadgeUploadResource.php
+++ b/app/Filament/Resources/Hotel/BadgeUploads/BadgeUploadResource.php
@@ -3,13 +3,10 @@
 namespace App\Filament\Resources\Hotel\BadgeUploads;
 
 use App\Filament\Resources\Hotel\BadgeUploads\Pages\ManageBadgeUploads;
-use Filament\Forms\Components\FileUpload;
 use Filament\Resources\Resource;
-use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Support\Facades\Storage;
-use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class BadgeUploadResource extends Resource
 {
@@ -24,23 +21,6 @@ class BadgeUploadResource extends Resource
         return hasHousekeepingPermission('manage_badges');
     }
 
-    public static function form(Schema $schema): Schema
-    {
-        return $schema
-            ->components([
-                FileUpload::make('badge_file')
-                    ->label('Upload Badge')
-                    ->disk('local')
-                    ->directory(setting('badge_path_filesystem'))
-                    ->required()
-                    ->getUploadedFileNameForStorageUsing(
-                        function (TemporaryUploadedFile $file): string {
-                            return strtolower(str_replace([' ', '-', 'æ', 'ø', 'å'], ['_', '_', 'ae', 'oe', 'aa'], $file->getClientOriginalName()));
-                        },
-                    ),
-            ]);
-    }
-
     public static function table(Table $table): Table
     {
         return $table
@@ -48,8 +28,6 @@ class BadgeUploadResource extends Resource
                 TextColumn::make('filename')
                     ->label('File Name')
                     ->sortable(),
-                TextColumn::make('path')
-                    ->label('File Path'),
             ])
             ->filters([]);
     }
@@ -63,14 +41,12 @@ class BadgeUploadResource extends Resource
 
     public static function getFiles(): array
     {
-        $badgePath = env('BadgePath', 'badges');
-        $files = Storage::disk('local')->files($badgePath);
+        $files = Storage::disk('badges')->files();
 
-        return collect($files)->map(function ($file) {
-            return [
-                'filename' => basename($file),
-                'path' => $file,
-            ];
-        })->toArray();
+        return collect($files)
+            ->filter(fn (string $file): bool => strtolower(pathinfo($file, PATHINFO_EXTENSION)) === 'gif')
+            ->map(fn (string $file): array => ['filename' => basename($file)])
+            ->values()
+            ->toArray();
     }
 }

--- a/app/Filament/Resources/Hotel/BadgeUploads/Pages/ManageBadgeUploads.php
+++ b/app/Filament/Resources/Hotel/BadgeUploads/Pages/ManageBadgeUploads.php
@@ -2,17 +2,21 @@
 
 namespace App\Filament\Resources\Hotel\BadgeUploads\Pages;
 
+use App\Rules\ValidBadgeUploadName;
+use App\Services\Badge\BadgeImageStorage;
+use App\Support\BadgeCode;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
-use Filament\Resources\Pages\Page; // Import the Notification class
+use Filament\Resources\Pages\Page;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 
 class ManageBadgeUploads extends Page implements HasForms
 {
     use InteractsWithForms;
 
-    public $badge_file;
+    public array|string|null $badge_file = null;
 
     protected static string $resource = 'App\Filament\Resources\Hotel\BadgeUploads\BadgeUploadResource';
 
@@ -29,16 +33,22 @@ class ManageBadgeUploads extends Page implements HasForms
             FileUpload::make('badge_file')
                 ->label('Upload Badge')
                 ->disk('badges')
-                ->preserveFilenames()
                 ->acceptedFileTypes(['image/gif'])
-                ->rules(['mimes:gif'])
+                ->maxSize(64)
+                ->rules(['mimetypes:image/gif', 'dimensions:width=40,height=40', new ValidBadgeUploadName])
+                ->saveUploadedFileUsing(function (TemporaryUploadedFile $file): string {
+                    $code = strtoupper(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME));
+                    app(BadgeImageStorage::class)->store($code, (string) $file->get());
+
+                    return BadgeCode::filename($code);
+                })
                 ->required(),
         ];
     }
 
     public function save(): void
     {
-        $data = $this->form->getState();
+        $this->form->getState();
 
         Notification::make()
             ->title('Badge uploaded successfully!')

--- a/app/Http/Controllers/Badge/BadgeController.php
+++ b/app/Http/Controllers/Badge/BadgeController.php
@@ -27,7 +27,7 @@ class BadgeController extends Controller
     {
         $badge = $createDrawnBadge->execute($request->user(), $request->validated());
 
-        return response()->json(['success' => true, 'badge_path_filesystem' => $badge->badge_path]);
+        return response()->json(['success' => true, 'badge_url' => $badge->badge_url]);
     }
 
     private function badgeFolderError(?string $path): ?string

--- a/app/Rules/ValidBadgeCode.php
+++ b/app/Rules/ValidBadgeCode.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Rules;
+
+use App\Support\BadgeCode;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use InvalidArgumentException;
+
+class ValidBadgeCode implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        try {
+            BadgeCode::normalize(is_string($value) ? $value : '');
+        } catch (InvalidArgumentException $exception) {
+            $fail($exception->getMessage());
+        }
+    }
+}

--- a/app/Rules/ValidBadgeUploadName.php
+++ b/app/Rules/ValidBadgeUploadName.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Rules;
+
+use App\Support\BadgeCode;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use InvalidArgumentException;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+
+class ValidBadgeUploadName implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! $value instanceof TemporaryUploadedFile) {
+            $fail('The badge upload is invalid.');
+
+            return;
+        }
+
+        $name = $value->getClientOriginalName();
+
+        if (basename($name) !== $name || strtolower(pathinfo($name, PATHINFO_EXTENSION)) !== 'gif') {
+            $fail('The badge filename must be a GIF filename without a path.');
+
+            return;
+        }
+
+        try {
+            BadgeCode::normalize(strtoupper(pathinfo($name, PATHINFO_FILENAME)));
+        } catch (InvalidArgumentException $exception) {
+            $fail($exception->getMessage());
+        }
+    }
+}

--- a/app/Services/Badge/BadgeImageNormalizer.php
+++ b/app/Services/Badge/BadgeImageNormalizer.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services\Badge;
+
+use RuntimeException;
+
+class BadgeImageNormalizer
+{
+    private const MAX_BYTES = 262_144;
+
+    private const SIZE = 40;
+
+    public function toGif(string $bytes): string
+    {
+        if ($bytes === '' || strlen($bytes) > self::MAX_BYTES) {
+            throw new RuntimeException('The badge image is empty or too large.');
+        }
+
+        $info = getimagesizefromstring($bytes);
+
+        if (
+            $info === false
+            || ! in_array($info['mime'], ['image/gif', 'image/png', 'image/jpeg'], true)
+            || $info[0] !== self::SIZE
+            || $info[1] !== self::SIZE
+        ) {
+            throw new RuntimeException('Badge images must be 40x40 GIF, PNG, or JPEG files.');
+        }
+
+        $image = imagecreatefromstring($bytes);
+
+        if ($image === false) {
+            throw new RuntimeException('The badge image could not be decoded.');
+        }
+
+        $bufferLevel = ob_get_level();
+        $gif = null;
+        ob_start();
+
+        try {
+            if (! imagegif($image)) {
+                throw new RuntimeException('The badge image could not be encoded.');
+            }
+
+            $gif = ob_get_clean();
+        } finally {
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+
+            imagedestroy($image);
+        }
+
+        if (! is_string($gif) || $gif === '') {
+            throw new RuntimeException('The badge image could not be encoded.');
+        }
+
+        return $gif;
+    }
+}

--- a/app/Services/Badge/BadgeImageStorage.php
+++ b/app/Services/Badge/BadgeImageStorage.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services\Badge;
+
+use App\Services\Files\AtomicFileWriter;
+use App\Support\BadgeCode;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+class BadgeImageStorage
+{
+    public function __construct(
+        private readonly RemoteBadgeImageFetcher $remoteImages,
+        private readonly BadgeImageNormalizer $normalizer,
+        private readonly AtomicFileWriter $files,
+    ) {}
+
+    public function storeRemote(string $code, string $url): void
+    {
+        $this->store($code, $this->remoteImages->fetch($url));
+    }
+
+    public function store(string $code, string $bytes): void
+    {
+        $path = Storage::disk('badges')->path(BadgeCode::filename($code));
+        File::ensureDirectoryExists(dirname($path));
+
+        $this->files->replace($path, $this->normalizer->toGif($bytes));
+    }
+}

--- a/app/Services/Badge/FlashExternalTexts.php
+++ b/app/Services/Badge/FlashExternalTexts.php
@@ -2,7 +2,10 @@
 
 namespace App\Services\Badge;
 
+use App\Services\Files\AtomicFileWriter;
 use App\Services\SettingsService;
+use App\Support\BadgeCode;
+use RuntimeException;
 
 /**
  * Maintains the badge name/description entries in the flash client's
@@ -11,13 +14,17 @@ use App\Services\SettingsService;
  */
 class FlashExternalTexts
 {
-    public function __construct(private readonly SettingsService $settings) {}
+    public function __construct(
+        private readonly SettingsService $settings,
+        private readonly AtomicFileWriter $files,
+    ) {}
 
     /**
      * @return array{title: string, description: string}|null null when the badge has no entries
      */
     public function find(string $badgeCode): ?array
     {
+        $badgeCode = BadgeCode::normalize($badgeCode);
         $texts = $this->all();
 
         $name = $texts["badge_name_{$badgeCode}"] ?? null;
@@ -38,34 +45,37 @@ class FlashExternalTexts
      */
     public function add(string $badgeCode, ?string $title, ?string $description): void
     {
+        $badgeCode = BadgeCode::normalize($badgeCode);
         $path = $this->path();
 
         if (! $path || ! file_exists($path) || ! is_writable($path)) {
-            return;
+            throw new RuntimeException('The Flash external texts file is not writable.');
         }
-
-        $lines = preg_split('/\r\n|\n/', rtrim((string) file_get_contents($path)));
-        $lines = $lines === false ? [] : $lines;
 
         $entries = [
-            "badge_name_{$badgeCode}" => (string) ($title ?? ''),
-            "badge_desc_{$badgeCode}" => (string) ($description ?? ''),
+            "badge_name_{$badgeCode}" => $this->singleLine($title),
+            "badge_desc_{$badgeCode}" => $this->singleLine($description),
         ];
 
-        foreach ($lines as $index => $line) {
-            [$key] = explode('=', $line, 2);
+        $this->files->update($path, function (string $contents) use ($entries): string {
+            $lines = preg_split('/\r\n|\n/', rtrim($contents));
+            $lines = $lines === false ? [] : $lines;
 
-            if (array_key_exists($key, $entries)) {
-                $lines[$index] = $key . '=' . $entries[$key];
-                unset($entries[$key]);
+            foreach ($lines as $index => $line) {
+                [$key] = explode('=', $line, 2);
+
+                if (array_key_exists($key, $entries)) {
+                    $lines[$index] = $key . '=' . $entries[$key];
+                    unset($entries[$key]);
+                }
             }
-        }
 
-        foreach ($entries as $key => $value) {
-            $lines[] = $key . '=' . $value;
-        }
+            foreach ($entries as $key => $value) {
+                $lines[] = $key . '=' . $value;
+            }
 
-        file_put_contents($path, implode("\n", $lines) . "\n");
+            return implode("\n", $lines) . "\n";
+        });
     }
 
     /**
@@ -98,5 +108,10 @@ class FlashExternalTexts
         $path = $this->settings->getOrDefault('flash_external_texts_file');
 
         return is_string($path) && $path !== '' ? $path : null;
+    }
+
+    private function singleLine(?string $value): string
+    {
+        return str_replace(["\r", "\n"], ' ', (string) $value);
     }
 }

--- a/app/Services/Badge/NitroExternalTexts.php
+++ b/app/Services/Badge/NitroExternalTexts.php
@@ -2,7 +2,11 @@
 
 namespace App\Services\Badge;
 
+use App\Services\Files\AtomicFileWriter;
 use App\Services\SettingsService;
+use App\Support\BadgeCode;
+use JsonException;
+use RuntimeException;
 
 /**
  * Maintains the badge name/description entries in the Nitro external texts
@@ -10,13 +14,17 @@ use App\Services\SettingsService;
  */
 class NitroExternalTexts
 {
-    public function __construct(private readonly SettingsService $settings) {}
+    public function __construct(
+        private readonly SettingsService $settings,
+        private readonly AtomicFileWriter $files,
+    ) {}
 
     /**
      * @return array{title: string, description: string}|null null when the badge has no entries
      */
     public function find(string $badgeCode): ?array
     {
+        $badgeCode = BadgeCode::normalize($badgeCode);
         $texts = $this->read();
 
         $name = $texts["badge_name_{$badgeCode}"] ?? null;
@@ -34,6 +42,7 @@ class NitroExternalTexts
 
     public function add(string $badgeCode, ?string $name, ?string $description): void
     {
+        $badgeCode = BadgeCode::normalize($badgeCode);
         $this->rewrite(fn (array $texts): array => array_merge($texts, [
             "badge_name_{$badgeCode}" => $name,
             "badge_desc_{$badgeCode}" => $description,
@@ -42,31 +51,42 @@ class NitroExternalTexts
 
     public function remove(string $badgeCode): void
     {
+        $badgeCode = BadgeCode::normalize($badgeCode);
         $this->rewrite(function (array $texts) use ($badgeCode): array {
             unset($texts["badge_name_{$badgeCode}"], $texts["badge_desc_{$badgeCode}"]);
 
             return $texts;
-        });
+        }, required: false);
     }
 
     /**
      * @param  callable(array<string, mixed>): array<string, mixed>  $mutate
      */
-    private function rewrite(callable $mutate): void
+    private function rewrite(callable $mutate, bool $required = true): void
     {
         $path = $this->path();
 
         if (! $path || ! file_exists($path) || ! is_writable($path)) {
+            if ($required) {
+                throw new RuntimeException('The Nitro external texts file is not writable.');
+            }
+
             return;
         }
 
-        $texts = json_decode((string) file_get_contents($path), true);
+        $this->files->update($path, function (string $contents) use ($mutate): string {
+            try {
+                $texts = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException $exception) {
+                throw new RuntimeException('The Nitro external texts file contains invalid JSON.', previous: $exception);
+            }
 
-        if (! is_array($texts)) {
-            return;
-        }
+            if (! is_array($texts)) {
+                throw new RuntimeException('The Nitro external texts file must contain a JSON object.');
+            }
 
-        file_put_contents($path, json_encode($mutate($texts), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            return json_encode($mutate($texts), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        });
     }
 
     /**

--- a/app/Services/Badge/RemoteBadgeImageFetcher.php
+++ b/app/Services/Badge/RemoteBadgeImageFetcher.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services\Badge;
+
+use App\Services\Network\PublicIpResolver;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Throwable;
+
+class RemoteBadgeImageFetcher
+{
+    private const MAX_BYTES = 262_144;
+
+    public function __construct(private readonly PublicIpResolver $resolver) {}
+
+    public function fetch(string $url): string
+    {
+        $parts = parse_url($url);
+
+        if (
+            ! is_array($parts)
+            || ($parts['scheme'] ?? null) !== 'https'
+            || ! isset($parts['host'])
+            || isset($parts['user'])
+            || isset($parts['pass'])
+            || (int) ($parts['port'] ?? 443) !== 443
+        ) {
+            throw new RuntimeException('Badge images must use a standard HTTPS URL without credentials.');
+        }
+
+        $host = strtolower($parts['host']);
+        $address = $this->resolver->resolveIpv4($host);
+
+        try {
+            $response = Http::connectTimeout(2)
+                ->timeout(5)
+                ->withOptions([
+                    'allow_redirects' => false,
+                    'curl' => [
+                        CURLOPT_IPRESOLVE => CURL_IPRESOLVE_V4,
+                        CURLOPT_PROTOCOLS => CURLPROTO_HTTPS,
+                        CURLOPT_PROXY => '',
+                        CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTPS,
+                        CURLOPT_RESOLVE => ["{$host}:443:{$address}"],
+                    ],
+                    'progress' => function (int $downloadTotal, int $downloadedBytes, int $uploadTotal, int $uploadedBytes): void {
+                        if ($downloadTotal > self::MAX_BYTES || $downloadedBytes > self::MAX_BYTES) {
+                            throw new RuntimeException('The remote badge image is too large.');
+                        }
+                    },
+                ])
+                ->accept('image/gif, image/png, image/jpeg')
+                ->get($url);
+        } catch (ConnectionException $exception) {
+            throw new RuntimeException('The remote badge image could not be downloaded.', previous: $exception);
+        } catch (Throwable $exception) {
+            throw $exception instanceof RuntimeException
+                ? $exception
+                : new RuntimeException('The remote badge image could not be downloaded.', previous: $exception);
+        }
+
+        if (! $response->successful() || strlen($response->body()) > self::MAX_BYTES) {
+            throw new RuntimeException('The remote badge image could not be downloaded.');
+        }
+
+        return $response->body();
+    }
+}

--- a/app/Services/Files/AtomicFileWriter.php
+++ b/app/Services/Files/AtomicFileWriter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services\Files;
+
+use RuntimeException;
+
+class AtomicFileWriter
+{
+    public function replace(string $path, string $contents): void
+    {
+        $this->update($path, static fn (): string => $contents);
+    }
+
+    /**
+     * @param  callable(string): string  $mutate
+     */
+    public function update(string $path, callable $mutate): void
+    {
+        if (! is_writable(dirname($path))) {
+            throw new RuntimeException("File is not readable and writable: {$path}");
+        }
+
+        $lock = fopen($path . '.lock', 'c');
+
+        if ($lock === false) {
+            throw new RuntimeException("Unable to lock file: {$path}");
+        }
+
+        if (! flock($lock, LOCK_EX)) {
+            fclose($lock);
+
+            throw new RuntimeException("Unable to lock file: {$path}");
+        }
+
+        $temporaryPath = null;
+
+        try {
+            $exists = file_exists($path);
+
+            if ($exists && (! is_file($path) || ! is_readable($path) || ! is_writable($path))) {
+                throw new RuntimeException("File is not readable and writable: {$path}");
+            }
+
+            $current = $exists ? file_get_contents($path) : '';
+
+            if ($current === false) {
+                throw new RuntimeException("Unable to read file: {$path}");
+            }
+
+            $updated = $mutate($current);
+            $temporaryPath = tempnam(dirname($path), '.atom-');
+
+            if ($temporaryPath === false || file_put_contents($temporaryPath, $updated) !== strlen($updated)) {
+                throw new RuntimeException("Unable to write temporary file for: {$path}");
+            }
+
+            $permissions = $exists ? fileperms($path) : 0644;
+
+            if ($permissions === false || ! chmod($temporaryPath, $permissions & 0777)) {
+                throw new RuntimeException("Unable to set file permissions for: {$path}");
+            }
+
+            if (! rename($temporaryPath, $path)) {
+                throw new RuntimeException("Unable to replace file: {$path}");
+            }
+
+            $temporaryPath = null;
+        } finally {
+            if ($temporaryPath !== null && file_exists($temporaryPath)) {
+                unlink($temporaryPath);
+            }
+
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+}

--- a/app/Services/Network/PublicIpResolver.php
+++ b/app/Services/Network/PublicIpResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services\Network;
+
+use RuntimeException;
+
+class PublicIpResolver
+{
+    public function resolveIpv4(string $host): string
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            return $this->ensurePublic($host);
+        }
+
+        if (! filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)) {
+            throw new RuntimeException('The remote image host is invalid.');
+        }
+
+        $records = dns_get_record($host, DNS_A);
+        $addresses = is_array($records)
+            ? array_values(array_filter(array_column($records, 'ip'), 'is_string'))
+            : [];
+
+        if ($addresses === []) {
+            throw new RuntimeException('The remote image host could not be resolved.');
+        }
+
+        foreach ($addresses as $address) {
+            $this->ensurePublic($address);
+        }
+
+        return $addresses[0];
+    }
+
+    private function ensurePublic(string $address): string
+    {
+        if (! filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+            throw new RuntimeException('Remote images must resolve only to public IPv4 addresses.');
+        }
+
+        return $address;
+    }
+}

--- a/app/Services/Parsers/ExternalTextsParser.php
+++ b/app/Services/Parsers/ExternalTextsParser.php
@@ -4,6 +4,9 @@ namespace App\Services\Parsers;
 
 use App\Services\Badge\FlashExternalTexts;
 use App\Services\Badge\NitroExternalTexts;
+use App\Services\SettingsService;
+use App\Support\BadgeCode;
+use Illuminate\Support\Facades\Storage;
 
 /**
  * Reads and writes a badge's name/description across the client text files -
@@ -15,6 +18,7 @@ class ExternalTextsParser
     public function __construct(
         private readonly NitroExternalTexts $nitroTexts,
         private readonly FlashExternalTexts $flashTexts,
+        private readonly SettingsService $settings,
     ) {}
 
     /**
@@ -26,8 +30,10 @@ class ExternalTextsParser
      */
     public function getBadgeData(string $code): array
     {
+        $code = BadgeCode::normalize($code);
+
         return [
-            'image' => file_exists($this->badgeImagePath($code)) ? $this->getBadgeImageUrl($code) : null,
+            'image' => Storage::disk('badges')->exists(BadgeCode::filename($code)) ? $this->getBadgeImageUrl($code) : null,
             'nitro' => $this->nitroTexts->find($code),
             'flash' => $this->flashTexts->find($code),
         ];
@@ -39,26 +45,21 @@ class ExternalTextsParser
      */
     public function updateNitroBadgeTexts(string $code, string $title = '', string $description = ''): void
     {
-        $this->nitroTexts->add($code, $title, $description);
+        $this->nitroTexts->add(BadgeCode::normalize($code), $title, $description);
     }
 
     public function updateFlashBadgeTexts(string $code, string $title = '', string $description = ''): void
     {
-        $this->flashTexts->add($code, $title, $description);
+        $this->flashTexts->add(BadgeCode::normalize($code), $title, $description);
     }
 
     public function getBadgeImageUrl(string $code): string
     {
-        return url(sprintf('%s/c_images/album1584/%s.gif', $this->clientPath(), $code));
-    }
+        $baseUrl = rtrim((string) $this->settings->getOrDefault('badges_path', '/badges'), '/');
+        $path = $baseUrl . '/' . rawurlencode(BadgeCode::normalize($code)) . '.gif';
 
-    private function badgeImagePath(string $code): string
-    {
-        return public_path(sprintf('%s/c_images/album1584/%s.gif', $this->clientPath(), $code));
-    }
-
-    private function clientPath(): string
-    {
-        return trim((string) config('hotel.client.flash.relative_files_path'), '/');
+        return str_starts_with($path, 'https://') || str_starts_with($path, 'http://')
+            ? $path
+            : url($path);
     }
 }

--- a/app/Support/BadgeCode.php
+++ b/app/Support/BadgeCode.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Support;
+
+use InvalidArgumentException;
+
+final class BadgeCode
+{
+    public static function normalize(string $code): string
+    {
+        $code = trim($code);
+
+        if (! preg_match('/\A[A-Za-z0-9_-]{1,32}\z/', $code)) {
+            throw new InvalidArgumentException('Badge codes may only contain letters, numbers, underscores, and hyphens.');
+        }
+
+        return $code;
+    }
+
+    public static function filename(string $code): string
+    {
+        return self::normalize($code) . '.gif';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,8 @@
     "license": "MIT",
     "require": {
         "php": "^8.5",
+        "ext-curl": "*",
+        "ext-gd": "*",
         "ext-sockets": "*",
         "doctrine/dbal": "^3.5",
         "filament/filament": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84dee998e19a29767e558363351f577b",
+    "content-hash": "c8dd09eb93a62249bc483160ed34b35f",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -14961,6 +14961,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.5",
+        "ext-curl": "*",
+        "ext-gd": "*",
         "ext-sockets": "*"
     },
     "platform-dev": {},

--- a/tests/Feature/Badge/BadgeAssetSecurityTest.php
+++ b/tests/Feature/Badge/BadgeAssetSecurityTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use App\Services\Badge\BadgeImageNormalizer;
+use App\Services\Badge\BadgeImageStorage;
+use App\Services\Badge\RemoteBadgeImageFetcher;
+use App\Services\Network\PublicIpResolver;
+use App\Support\BadgeCode;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+function badgeImageBytes(string $format = 'png', int $width = 40, int $height = 40): string
+{
+    $image = imagecreatetruecolor($width, $height);
+    ob_start();
+
+    match ($format) {
+        'gif' => imagegif($image),
+        'jpeg' => imagejpeg($image),
+        default => imagepng($image),
+    };
+
+    $bytes = ob_get_clean();
+    imagedestroy($image);
+
+    return (string) $bytes;
+}
+
+test('badge codes cannot traverse the badge directory', function () {
+    expect(fn () => BadgeCode::filename('../outside'))->toThrow(InvalidArgumentException::class)
+        ->and(fn () => BadgeCode::filename('SAFE_CODE-1'))->not->toThrow(InvalidArgumentException::class);
+});
+
+test('remote badge images reject non-https addresses before sending', function () {
+    Http::fake();
+    $fetcher = app(RemoteBadgeImageFetcher::class);
+
+    expect(fn () => $fetcher->fetch('http://127.0.0.1/internal.gif'))
+        ->toThrow(RuntimeException::class);
+
+    Http::assertNothingSent();
+});
+
+test('remote badge images reject private addresses before sending', function () {
+    Http::fake();
+
+    expect(fn () => app(RemoteBadgeImageFetcher::class)->fetch('https://127.0.0.1/internal.gif'))
+        ->toThrow(RuntimeException::class);
+
+    Http::assertNothingSent();
+});
+
+test('the public IP resolver rejects private addresses', function () {
+    expect(fn () => app(PublicIpResolver::class)->resolveIpv4('127.0.0.1'))
+        ->toThrow(RuntimeException::class);
+});
+
+test('remote badge images are fetched once and normalized to a 40x40 gif', function () {
+    $resolver = Mockery::mock(PublicIpResolver::class);
+    $resolver->shouldReceive('resolveIpv4')->once()->with('assets.example.com')->andReturn('93.184.216.34');
+    Http::fake([
+        'https://assets.example.com/badge.png' => Http::response(badgeImageBytes(), 200, ['Content-Type' => 'image/png']),
+    ]);
+
+    $fetcher = new RemoteBadgeImageFetcher($resolver);
+    $gif = app(BadgeImageNormalizer::class)->toGif($fetcher->fetch('https://assets.example.com/badge.png'));
+    $info = getimagesizefromstring($gif);
+
+    expect($info)->not->toBeFalse()
+        ->and($info['mime'])->toBe('image/gif')
+        ->and($info[0])->toBe(40)
+        ->and($info[1])->toBe(40);
+
+    Http::assertSentCount(1);
+});
+
+test('badge storage rejects invalid dimensions and never writes outside its disk', function () {
+    Storage::fake('badges');
+    $storage = app(BadgeImageStorage::class);
+
+    expect(fn () => $storage->store('BADGE', badgeImageBytes(width: 41)))
+        ->toThrow(RuntimeException::class);
+
+    expect(Storage::disk('badges')->allFiles())->toBeEmpty();
+
+    $storage->store('BADGE', badgeImageBytes());
+
+    Storage::disk('badges')->assertExists('BADGE.gif');
+
+    expect(fileperms(Storage::disk('badges')->path('BADGE.gif')) & 0777)->toBe(0644);
+});

--- a/tests/Feature/Badge/BadgePurchaseTest.php
+++ b/tests/Feature/Badge/BadgePurchaseTest.php
@@ -40,7 +40,7 @@ test('buying a drawn badge charges credits and stores the file', function () {
 
     $user = User::factory()->create(['credits' => 1000]);
 
-    $this->actingAs($user)
+    $response = $this->actingAs($user)
         ->post(route('badge.buy'), drawnBadgePayload())
         ->assertOk()
         ->assertJson(['success' => true]);
@@ -49,6 +49,8 @@ test('buying a drawn badge charges credits and stores the file', function () {
 
     expect($badge)->not->toBeNull()
         ->and(file_exists($badge->badge_path))->toBeTrue()
+        ->and($response->json('badge_url'))->toBe($badge->badge_url)
+        ->and($response->json('badge_path_filesystem'))->toBeNull()
         ->and((int) $user->refresh()->credits)->toBe(850);
 });
 

--- a/tests/Feature/Badge/ExternalTextsParserTest.php
+++ b/tests/Feature/Badge/ExternalTextsParserTest.php
@@ -2,10 +2,12 @@
 
 use App\Services\Parsers\ExternalTextsParser;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 
 function externalTextsSetup(): ExternalTextsParser
 {
     installHotel();
+    Storage::fake('badges');
 
     $directory = storage_path('framework/testing/external-texts');
     File::ensureDirectoryExists($directory);
@@ -26,6 +28,7 @@ function externalTextsSetup(): ExternalTextsParser
 
     setSetting('nitro_external_texts_file', $nitroPath);
     setSetting('flash_external_texts_file', $flashPath);
+    setSetting('badges_path', '/testing-badges');
 
     return app(ExternalTextsParser::class);
 }
@@ -83,21 +86,24 @@ test('updating an existing badge rewrites its lines in place', function () {
         ->and(substr_count($flash, 'badge_name_ACH_Existing='))->toBe(1);
 });
 
-test('the badge image url and existence follow the flash client path', function () {
+test('the badge image url and existence follow the configured badge disk', function () {
     $parser = externalTextsSetup();
 
-    config(['hotel.client.flash.relative_files_path' => 'testing-client']);
+    expect($parser->getBadgeImageUrl('ACH_Img'))->toBe(url('/testing-badges/ACH_Img.gif'));
 
-    expect($parser->getBadgeImageUrl('ACH_Img'))->toBe(url('testing-client/c_images/album1584/ACH_Img.gif'));
+    Storage::disk('badges')->put('ACH_Img.gif', 'gif');
 
-    $imageDir = public_path('testing-client/c_images/album1584');
-    File::ensureDirectoryExists($imageDir);
-    file_put_contents($imageDir . '/ACH_Img.gif', 'gif');
+    expect($parser->getBadgeData('ACH_Img')['image'])
+        ->toBe(url('/testing-badges/ACH_Img.gif'));
+});
 
-    try {
-        expect($parser->getBadgeData('ACH_Img')['image'])
-            ->toBe(url('testing-client/c_images/album1584/ACH_Img.gif'));
-    } finally {
-        File::deleteDirectory(public_path('testing-client'));
-    }
+test('flash badge text values cannot inject additional lines', function () {
+    $parser = externalTextsSetup();
+
+    $parser->updateFlashBadgeTexts('ACH_Safe', "Safe\nmalicious.key=owned", 'Description');
+
+    $flash = (string) file_get_contents(storage_path('framework/testing/external-texts/external_flash_texts.txt'));
+
+    expect($flash)->toContain('badge_name_ACH_Safe=Safe malicious.key=owned')
+        ->not->toContain("\nmalicious.key=owned");
 });


### PR DESCRIPTION
## Summary
- validate badge codes and filenames before constructing filesystem paths
- fetch remote images once over pinned public HTTPS without redirects or proxies
- decode, validate, and re-encode all remote and manual badge uploads
- update Nitro and Flash external texts through locked atomic replacements
- return the public badge URL without exposing server filesystem paths
- declare the required curl and GD PHP extensions

## Verification
- `vendor/bin/pest --compact` - 148 tests, 420 assertions
- `vendor/bin/pest tests/Feature/Badge/ExternalTextsParserTest.php tests/Feature/Badge/BadgePurchaseTest.php tests/Feature/Badge/BadgeAssetSecurityTest.php --compact` - 15 tests, 51 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `composer validate --strict --no-check-publish`
- `vendor/bin/pint` on changed PHP files