### PR TITLE
fix: enforce article comment authorization

### DIFF
--- a/app/Http/Controllers/Articles/WebsiteArticleCommentsController.php
+++ b/app/Http/Controllers/Articles/WebsiteArticleCommentsController.php
@@ -8,6 +8,7 @@ use App\Models\Articles\WebsiteArticle;
 use App\Models\Articles\WebsiteArticleComment;
 use App\Services\Articles\CommentService;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 
 class WebsiteArticleCommentsController extends Controller
 {
@@ -15,14 +16,14 @@ class WebsiteArticleCommentsController extends Controller
 
     public function store(WebsiteArticle $article, ArticleCommentFormRequest $request): RedirectResponse
     {
-        $this->commentService->store($request->get('comment'), $article);
+        $this->commentService->store($request->user(), $request->string('comment')->toString(), $article);
 
         return redirect()->back()->with('success', __('You comment has been posted!'));
     }
 
-    public function destroy(WebsiteArticleComment $comment): RedirectResponse
+    public function destroy(WebsiteArticleComment $comment, Request $request): RedirectResponse
     {
-        $this->commentService->destroy($comment);
+        $this->commentService->destroy($request->user(), $comment);
 
         return redirect()->back()->with('success', __('You comment has been deleted!'));
     }

--- a/app/Livewire/ArticleComments.php
+++ b/app/Livewire/ArticleComments.php
@@ -5,6 +5,8 @@ namespace App\Livewire;
 use App\Models\Articles\WebsiteArticle;
 use App\Models\Articles\WebsiteArticleComment;
 use App\Rules\WebsiteWordfilterRule;
+use App\Services\Articles\CommentService;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
@@ -21,28 +23,16 @@ class ArticleComments extends Component
         $this->article = $article;
     }
 
-    public function postComment(): void
+    public function postComment(CommentService $comments): void
     {
+        $user = Auth::user();
+        abort_if($user === null, 403);
+
         $this->validate([
             'comment' => ['required', 'string', 'min:2', 'max:255', new WebsiteWordfilterRule],
         ]);
 
-        if ($this->article->userHasReachedArticleCommentLimit()) {
-            $this->addError('comment', __('You can only comment :amount times per article', ['amount' => setting('max_comment_per_article')]));
-
-            return;
-        }
-
-        if (! $this->article->can_comment) {
-            $this->addError('comment', __('This article has been locked from receiving comments'));
-
-            return;
-        }
-
-        $this->article->comments()->create([
-            'user_id' => auth()->id(),
-            'comment' => $this->comment,
-        ]);
+        $comments->store($user, $this->comment, $this->article);
 
         $this->comment = '';
 
@@ -50,22 +40,17 @@ class ArticleComments extends Component
         $this->dispatch('toast', icon: 'success', title: __('Comment posted successfully'));
     }
 
-    public function deleteComment(int $commentId): void
+    public function deleteComment(int $commentId, CommentService $comments): void
     {
+        $user = Auth::user();
+        abort_if($user === null, 403);
+
         /** @var WebsiteArticleComment|null $comment */
         $comment = $this->article->comments()->find($commentId);
 
-        if (! $comment) {
-            return;
-        }
+        abort_if($comment === null, 404);
 
-        if (! $comment->canBeDeleted()) {
-            $this->addError('comment', __('You can only delete your own comments'));
-
-            return;
-        }
-
-        $comment->delete();
+        $comments->destroy($user, $comment);
 
         $this->dispatch('toast', icon: 'success', title: __('Comment deleted successfully'));
     }

--- a/app/Models/Articles/WebsiteArticle.php
+++ b/app/Models/Articles/WebsiteArticle.php
@@ -87,6 +87,9 @@ class WebsiteArticle extends Model
             ->whereActive(true);
     }
 
+    /**
+     * @return HasMany<WebsiteArticleComment, $this>
+     */
     public function comments(): HasMany
     {
         return $this->hasMany(WebsiteArticleComment::class, 'article_id');

--- a/app/Models/Articles/WebsiteArticleComment.php
+++ b/app/Models/Articles/WebsiteArticleComment.php
@@ -6,7 +6,6 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
 
 /**
  * @property int $id
@@ -42,10 +41,5 @@ class WebsiteArticleComment extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
-    }
-
-    public function canBeDeleted(): bool
-    {
-        return $this->user_id === Auth::id() || hasPermission('delete_article_comments');
     }
 }

--- a/app/Policies/WebsiteArticleCommentPolicy.php
+++ b/app/Policies/WebsiteArticleCommentPolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Articles\WebsiteArticleComment;
+use App\Models\User;
+use App\Services\PermissionsService;
+
+class WebsiteArticleCommentPolicy
+{
+    public function __construct(private readonly PermissionsService $permissions) {}
+
+    public function delete(User $user, WebsiteArticleComment $comment): bool
+    {
+        return $comment->user_id === $user->id
+            || $this->permissions->allows($user, 'delete_article_comments');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,9 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Models\Articles\WebsiteArticleComment;
 use App\Policies\ActivityPolicy;
+use App\Policies\WebsiteArticleCommentPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Spatie\Activitylog\Models\Activity;
 
@@ -15,8 +17,8 @@ class AuthServiceProvider extends ServiceProvider
      * @var array<class-string, class-string>
      */
     protected $policies = [
-        // 'App\Models\Model' => 'App\Policies\ModelPolicy',
         Activity::class => ActivityPolicy::class,
+        WebsiteArticleComment::class => WebsiteArticleCommentPolicy::class,
     ];
 
     /**

--- a/app/Services/Articles/CommentService.php
+++ b/app/Services/Articles/CommentService.php
@@ -4,45 +4,40 @@ namespace App\Services\Articles;
 
 use App\Models\Articles\WebsiteArticle;
 use App\Models\Articles\WebsiteArticleComment;
-use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Auth;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
 
 class CommentService
 {
-    public function store(string $comment, WebsiteArticle $article): mixed
+    public function store(User $user, string $comment, WebsiteArticle $article): WebsiteArticleComment
     {
-        if ($article->userHasReachedArticleCommentLimit()) {
-            return redirect()->back()->withErrors([
-                'message' => __('You can only comment :amount times per article', ['amount' => setting('max_comment_per_article')]),
-            ]);
-        }
+        return DB::transaction(function () use ($user, $comment, $article): WebsiteArticleComment {
+            $article = WebsiteArticle::whereKey($article->id)->lockForUpdate()->firstOrFail();
 
-        if (! $article->can_comment) {
-            return redirect()->back()->withErrors([
-                'message' => __('This article has been locked from receiving comments'),
-            ]);
-        }
+            if ($article->comments()->where('user_id', $user->id)->count() >= (int) setting('max_comment_per_article')) {
+                throw ValidationException::withMessages([
+                    'comment' => __('You can only comment :amount times per article', ['amount' => setting('max_comment_per_article')]),
+                ]);
+            }
 
-        return $article->comments()->create([
-            'user_id' => Auth::id(),
-            'comment' => $comment,
-        ]);
+            if (! $article->can_comment) {
+                throw ValidationException::withMessages([
+                    'comment' => __('This article has been locked from receiving comments'),
+                ]);
+            }
+
+            return $article->comments()->create([
+                'user_id' => $user->id,
+                'comment' => $comment,
+            ]);
+        }, attempts: 3);
     }
 
-    public function destroy(WebsiteArticleComment $comment): bool|RedirectResponse|null
+    public function destroy(User $user, WebsiteArticleComment $comment): void
     {
-        if (! $comment->canBeDeleted()) {
-            return redirect()->back()->withErrors([
-                'message' => __('You can only delete your own comments'),
-            ]);
-        }
-
-        if (! $comment->delete()) {
-            return redirect()->back()->withErrors([
-                'message' => __('An error occurred while deleting the comment'),
-            ]);
-        }
-
-        return true;
+        Gate::forUser($user)->authorize('delete', $comment);
+        $comment->deleteOrFail();
     }
 }

--- a/app/Services/PermissionsService.php
+++ b/app/Services/PermissionsService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Miscellaneous\WebsitePermission;
+use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -21,10 +22,17 @@ class PermissionsService
 
     public function getOrDefault(string $permissionName, bool $default = false): bool
     {
+        $user = auth()->user();
+
+        return $user !== null && $this->allows($user, $permissionName, $default);
+    }
+
+    public function allows(User $user, string $permissionName, bool $default = false): bool
+    {
         if (! $this->permissions->has($permissionName)) {
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $this->permissions->get($permissionName);
+        return $user->rank >= (int) $this->permissions->get($permissionName);
     }
 }

--- a/resources/views/livewire/article-comments.blade.php
+++ b/resources/views/livewire/article-comments.blade.php
@@ -1,7 +1,7 @@
 @php($theme = setting('theme', 'dusk'))
 
 <div class="space-y-4">
-    @if ($article->can_comment)
+    @if (auth()->check() && $article->can_comment)
         @if (auth()->check() && !$article->userHasReachedArticleCommentLimit())
             <x-content.content-card icon="hotel-icon">
                 <x-slot:title>
@@ -74,7 +74,7 @@
                                                 {{ $comment->created_at->diffForHumans() }}
                                             </p>
 
-                                            @if ($comment->canBeDeleted())
+                                            @can('delete', $comment)
                                                 <button wire:click="deleteComment({{ $comment->id }})"
                                                     class="rounded p-1 {{ $theme === 'dusk' ? 'text-gray-300 hover:text-red-400 hover:bg-red-500/10' : 'text-gray-500 dark:text-gray-300 hover:text-red-500 hover:bg-red-500/10' }} transition"
                                                     title="{{ __('Delete comment') }}">
@@ -85,7 +85,7 @@
                                                               d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                                                     </svg>
                                                 </button>
-                                            @endif
+                                            @endcan
                                         </div>
                                     </div>
 

--- a/tests/Feature/Community/ArticleInteractionsTest.php
+++ b/tests/Feature/Community/ArticleInteractionsTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Livewire\ArticleComments;
 use App\Models\Articles\WebsiteArticle;
 use App\Models\User;
+use Livewire\Livewire;
 
 function publishArticle(User $author): WebsiteArticle
 {
@@ -60,9 +62,48 @@ test('a reader cannot delete someone else\'s comment', function () {
 
     $this->actingAs($stranger)
         ->delete(route('article.comment.destroy', $comment))
-        ->assertSessionHasErrors();
+        ->assertForbidden();
 
     expect($article->comments()->count())->toBe(1);
+});
+
+test('a guest cannot post through the public article livewire component', function () {
+    $article = publishArticle($this->author);
+
+    Livewire::test(ArticleComments::class, ['article' => $article])
+        ->set('comment', 'Anonymous comment')
+        ->call('postComment')
+        ->assertForbidden();
+
+    expect($article->comments()->count())->toBe(0);
+});
+
+test('livewire enforces comment ownership when deleting', function () {
+    $article = publishArticle($this->author);
+    $comment = $article->comments()->create([
+        'user_id' => $this->reader->id,
+        'comment' => 'Owned by the reader',
+    ]);
+    $stranger = User::factory()->create();
+
+    Livewire::actingAs($stranger)
+        ->test(ArticleComments::class, ['article' => $article])
+        ->call('deleteComment', $comment->id)
+        ->assertForbidden();
+
+    expect($comment->fresh())->not->toBeNull();
+});
+
+test('a locked article reports the failure instead of flashing success', function () {
+    $article = publishArticle($this->author);
+    $article->update(['can_comment' => false]);
+
+    $this->actingAs($this->reader)
+        ->post(route('article.comment.store', $article->slug), ['comment' => 'Should not persist'])
+        ->assertSessionHasErrors('comment')
+        ->assertSessionMissing('success');
+
+    expect($article->comments()->count())->toBe(0);
 });
 
 test('a reader can toggle a reaction', function () {


### PR DESCRIPTION
## Summary
- forbid unauthenticated mutations from the Livewire comments component on public article pages
- move comment deletion authorization from auth-aware model code into a registered policy
- centralize HTTP and Livewire comment writes in a typed service
- serialize per-article comment-limit checks and propagate validation, authorization, and persistence failures
- hide the comment form from guests while keeping public comments readable

## Verification
- `vendor/bin/pest` - 144 passed, 408 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint`
- Prettier check for the Livewire comment view
- `git diff --check`