### PR TITLE
fix: harden outbound HTTP integrations

### DIFF
--- a/app/Http/Middleware/FindRetrosMiddleware.php
+++ b/app/Http/Middleware/FindRetrosMiddleware.php
@@ -10,12 +10,12 @@ use Symfony\Component\HttpFoundation\Response;
 /* Credits to Kani for this */
 class FindRetrosMiddleware
 {
+    public function __construct(private readonly FindRetrosService $findRetros) {}
+
     public function handle(Request $request, Closure $next): Response
     {
-        $findRetrosService = new FindRetrosService;
-
-        if (config('habbo.findretros.enabled') && ! $findRetrosService->checkHasVoted()) {
-            return redirect($findRetrosService->getRedirectUri());
+        if (config('habbo.findretros.enabled') && ! $this->findRetros->checkHasVoted($request)) {
+            return redirect($this->findRetros->getRedirectUri());
         }
 
         return $next($request);

--- a/app/Http/Middleware/VPNCheckerMiddleware.php
+++ b/app/Http/Middleware/VPNCheckerMiddleware.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class VPNCheckerMiddleware
 {
+    public function __construct(private readonly IpLookupService $ipLookup) {}
+
     public function handle(Request $request, Closure $next): Response
     {
         if ($this->shouldSkip($request)) {
@@ -37,7 +39,7 @@ class VPNCheckerMiddleware
     private function checkReputation(Request $request, Closure $next): Response
     {
         $ip = $request->ip();
-        $apiResponse = (new IpLookupService(setting('ipdata_api_key')))->ipLookup($ip);
+        $apiResponse = $this->ipLookup->ipLookup($ip, (string) setting('ipdata_api_key'));
         $asn = $apiResponse['asn']['asn'] ?? '';
 
         if ($this->asnListed($asn, WebsiteIpWhitelist::class, 'whitelist_asn')) {

--- a/app/Jobs/SendRegisteredUserWebhook.php
+++ b/app/Jobs/SendRegisteredUserWebhook.php
@@ -2,13 +2,16 @@
 
 namespace App\Jobs;
 
+use App\Support\DiscordWebhookUrl;
+use App\Support\OutboundHttp;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
 
 /**
  * Notifies the configured Discord webhook about a new registration. Dispatched
@@ -17,6 +20,11 @@ use Illuminate\Support\Facades\Log;
 class SendRegisteredUserWebhook implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    /** @var list<int> */
+    public array $backoff = [10, 60, 300];
 
     public function __construct(
         private readonly string $username,
@@ -28,25 +36,33 @@ class SendRegisteredUserWebhook implements ShouldQueue
     {
         $url = setting('discord_webhook_url');
 
-        if (! $url) {
-            Log::error('Discord webhook url not provided', ['Please provide a discord webhook url before being able to send any webhook requests.']);
+        if (! DiscordWebhookUrl::isValid($url)) {
+            Log::error('Discord registration webhook URL is missing or invalid.');
 
             return;
         }
 
-        $response = Http::asJson()->post($url, [
-            'username' => sprintf('%s Bot', setting('hotel_name')),
-            'content' => "User: {$this->username} has just registered, with the IP: {$this->ip} and E-mail: {$this->email}",
-        ]);
+        try {
+            $response = OutboundHttp::request()
+                ->asJson()
+                ->post($url, [
+                    'username' => sprintf('%s Bot', setting('hotel_name')),
+                    'content' => "User: {$this->username} has just registered, with the IP: {$this->ip} and E-mail: {$this->email}",
+                ]);
+        } catch (Throwable $exception) {
+            Log::warning('Discord registration webhook delivery failed.', [
+                'exception_class' => $exception::class,
+            ]);
+
+            throw new RuntimeException('Discord registration webhook delivery failed.');
+        }
 
         if (! $response->successful()) {
-            Log::error('Failed to send Discord webhook notification', [
-                'username' => $this->username,
-                'ip' => $this->ip,
-                'email' => $this->email,
-                'response_status' => $response->status(),
-                'response_body' => $response->body(),
+            Log::warning('Discord registration webhook returned an error.', [
+                'status' => $response->status(),
             ]);
+
+            throw new RuntimeException('Discord registration webhook delivery failed.');
         }
     }
 }

--- a/app/Rules/GoogleRecaptchaRule.php
+++ b/app/Rules/GoogleRecaptchaRule.php
@@ -2,9 +2,10 @@
 
 namespace App\Rules;
 
+use App\Support\OutboundHttp;
 use Closure;
-use GuzzleHttp\Client;
 use Illuminate\Contracts\Validation\InvokableRule;
+use Illuminate\Http\Client\ConnectionException;
 
 class GoogleRecaptchaRule implements InvokableRule
 {
@@ -15,27 +16,27 @@ class GoogleRecaptchaRule implements InvokableRule
             return;
         }
 
-        $client = new Client;
-
-        $response = $client->request(
-            'POST', 'https://www.google.com/recaptcha/api/siteverify', [
-                'form_params' => [
+        try {
+            $response = OutboundHttp::request()
+                ->asForm()
+                ->post('https://www.google.com/recaptcha/api/siteverify', [
                     'secret' => config('habbo.site.recaptcha_secret_key'),
                     'response' => $value,
                     'remoteip' => request()->ip(),
-                ],
-            ],
-        );
+                ]);
+        } catch (ConnectionException) {
+            $fail(__('The Google recaptcha could not be verified. Please try again.'));
 
-        if ($response->getStatusCode() !== 200) {
+            return;
+        }
+
+        if (! $response->successful()) {
             $fail(__('The Google recaptcha was not successful.'));
 
             return;
         }
 
-        $body = json_decode((string) $response->getBody());
-
-        if (! $body->success) {
+        if ($response->json('success') !== true) {
             $fail(__('The Google recaptcha was not successful.'));
         }
     }

--- a/app/Services/FindRetrosService.php
+++ b/app/Services/FindRetrosService.php
@@ -2,53 +2,35 @@
 
 namespace App\Services;
 
-use GuzzleHttp\Client;
+use App\Support\OutboundHttp;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 
 /* Credits to Kani for this */
 
 class FindRetrosService
 {
-    /**
-     * The findretros verification uri.
-     */
-    public const FIND_RETROS_VERIFY_URI = '%s/validate.php?user=%s&ip=%s';
-
-    /**
-     * The findretros redirect uri.
-     */
-    public const FIND_RETROS_REDIRECT_URI = '%s/servers/%s/vote?minimal=1&return=1';
-
     public const FIND_RETROS_CACHE_KEY = 'voted.%s';
-
-    /**
-     * The guzzle client instance
-     */
-    protected Client $client;
-
-    /**
-     * Initialise Find Retros Service
-     */
-    public function __construct()
-    {
-        $this->client = new Client(['verify' => false]);
-    }
 
     /**
      * Check the user has voted.
      */
-    public function checkHasVoted(): bool
+    public function checkHasVoted(Request $request): bool
     {
         if (! config('habbo.findretros.enabled')) {
             return true;
         }
 
-        $cacheKey = sprintf(self::FIND_RETROS_CACHE_KEY, request()->ip());
-        if (request()->ip() === '127.0.0.1') {
+        $ip = $request->ip();
+        $cacheKey = sprintf(self::FIND_RETROS_CACHE_KEY, $ip);
+
+        if ($ip === '127.0.0.1') {
             return true;
         }
 
-        if (request()->has('novote')) {
+        if ($request->has('novote')) {
             return true;
         }
 
@@ -56,11 +38,30 @@ class FindRetrosService
             return true;
         }
 
-        $uri = sprintf(self::FIND_RETROS_VERIFY_URI, config('habbo.findretros.api'), config('habbo.findretros.name'), request()->ip());
-        $request = $this->client->get($uri);
-        $response = $request->getBody()->getContents();
+        try {
+            $response = OutboundHttp::request()
+                ->accept('text/plain')
+                ->get(rtrim((string) config('habbo.findretros.api'), '/') . '/validate.php', [
+                    'user' => config('habbo.findretros.name'),
+                    'ip' => $ip,
+                ]);
+        } catch (ConnectionException $exception) {
+            Log::warning('FindRetros verification was unavailable.', [
+                'exception_class' => $exception::class,
+            ]);
 
-        if (in_array($response, ['1', '2'])) {
+            return true;
+        }
+
+        if (! $response->successful()) {
+            Log::warning('FindRetros verification returned an error.', [
+                'status' => $response->status(),
+            ]);
+
+            return true;
+        }
+
+        if (in_array(trim($response->body()), ['1', '2'], true)) {
             Cache::put($cacheKey, true, now()->addMinutes(30));
 
             return true;
@@ -74,6 +75,10 @@ class FindRetrosService
      */
     public function getRedirectUri(): string
     {
-        return sprintf(self::FIND_RETROS_REDIRECT_URI, config('habbo.findretros.api'), config('habbo.findretros.name'));
+        return sprintf(
+            '%s/servers/%s/vote?minimal=1&return=1',
+            rtrim((string) config('habbo.findretros.api'), '/'),
+            rawurlencode((string) config('habbo.findretros.name')),
+        );
     }
 }

--- a/app/Services/IpLookupService.php
+++ b/app/Services/IpLookupService.php
@@ -2,28 +2,41 @@
 
 namespace App\Services;
 
-use Illuminate\Support\Facades\Http;
+use App\Support\OutboundHttp;
+use Illuminate\Http\Client\ConnectionException;
 
 class IpLookupService
 {
     private string $baseUrl = 'https://api.ipdata.co';
 
-    public function __construct(private string $apiKey) {}
-
-    /** @return array<string, mixed> */
-    public function ipLookup(string $ip): array
+    /**
+     * @return array<string, mixed>
+     */
+    public function ipLookup(string $ip, string $apiKey): array
     {
-        $response = Http::acceptJson()->get(sprintf('%s/%s?api-key=%s', $this->baseUrl, $ip, $this->apiKey));
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6) === false) {
+            return ['message' => 'Invalid IP address.', 'status' => 422];
+        }
+
+        try {
+            $response = OutboundHttp::request()
+                ->acceptJson()
+                ->get($this->baseUrl . '/' . rawurlencode($ip), ['api-key' => $apiKey]);
+        } catch (ConnectionException) {
+            return ['message' => 'IP reputation service unavailable.', 'status' => 503];
+        }
 
         if (! $response->ok()) {
-            $message = array_key_exists('message', $response->json()) ? $response->json()['message'] : 'Unknown error';
+            $message = $response->json('message');
 
             return [
-                'message' => $message,
+                'message' => is_string($message) ? $message : 'Unknown error',
                 'status' => $response->status(),
             ];
         }
 
-        return $response->json();
+        $payload = $response->json();
+
+        return is_array($payload) ? $payload : ['message' => 'Invalid response.', 'status' => 502];
     }
 }

--- a/app/Support/DiscordWebhookUrl.php
+++ b/app/Support/DiscordWebhookUrl.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Support;
+
+final class DiscordWebhookUrl
+{
+    public static function isValid(mixed $url): bool
+    {
+        if (! is_string($url) || strlen($url) > 2048) {
+            return false;
+        }
+
+        $parts = parse_url($url);
+
+        if (! is_array($parts)) {
+            return false;
+        }
+
+        $host = strtolower((string) ($parts['host'] ?? ''));
+        $path = (string) ($parts['path'] ?? '');
+
+        $isDiscordHost = $host === 'discord.com'
+            || str_ends_with($host, '.discord.com')
+            || $host === 'discordapp.com'
+            || str_ends_with($host, '.discordapp.com');
+
+        return ($parts['scheme'] ?? null) === 'https'
+            && ! isset($parts['user'], $parts['pass'], $parts['port'], $parts['query'], $parts['fragment'])
+            && $isDiscordHost
+            && preg_match('#^/api(?:/v\d+)?/webhooks/\d+/[A-Za-z0-9._-]+/?$#D', $path) === 1;
+    }
+}

--- a/app/Support/OutboundHttp.php
+++ b/app/Support/OutboundHttp.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+final class OutboundHttp
+{
+    public static function request(): PendingRequest
+    {
+        return Http::connectTimeout(3)
+            ->timeout(10)
+            ->retry([200, 500], throw: false)
+            ->withOptions(['verify' => true]);
+    }
+}

--- a/tests/Feature/Services/OutboundHttpTest.php
+++ b/tests/Feature/Services/OutboundHttpTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Jobs\SendRegisteredUserWebhook;
+use App\Rules\GoogleRecaptchaRule;
+use App\Services\FindRetrosService;
+use App\Services\IpLookupService;
+use App\Support\DiscordWebhookUrl;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+beforeEach(function () {
+    installHotel();
+    Cache::flush();
+});
+
+test('discord webhook URLs are restricted to official HTTPS endpoints', function () {
+    expect(DiscordWebhookUrl::isValid('https://discord.com/api/webhooks/123/token_value'))
+        ->toBeTrue()
+        ->and(DiscordWebhookUrl::isValid('https://canary.discord.com/api/v10/webhooks/123/token-value'))
+        ->toBeTrue()
+        ->and(DiscordWebhookUrl::isValid('http://discord.com/api/webhooks/123/token'))
+        ->toBeFalse()
+        ->and(DiscordWebhookUrl::isValid('https://discord.com.evil.test/api/webhooks/123/token'))
+        ->toBeFalse()
+        ->and(DiscordWebhookUrl::isValid('https://discord.com@127.0.0.1/api/webhooks/123/token'))
+        ->toBeFalse();
+});
+
+test('findretros uses encoded HTTPS requests and fails open on service errors', function () {
+    config()->set('habbo.findretros.enabled', true);
+    config()->set('habbo.findretros.name', 'Atom Hotel');
+    config()->set('habbo.findretros.api', 'https://findretros.com');
+    $request = Request::create('/', 'GET', server: ['REMOTE_ADDR' => '203.0.113.10']);
+
+    Http::fake([
+        'findretros.com/*' => Http::response('service unavailable', 503),
+    ]);
+
+    expect(app(FindRetrosService::class)->checkHasVoted($request))->toBeTrue();
+
+    expect(app(FindRetrosService::class)->getRedirectUri())
+        ->toBe('https://findretros.com/servers/Atom%20Hotel/vote?minimal=1&return=1');
+
+    Http::assertSent(fn ($outbound) => $outbound->url() === 'https://findretros.com/validate.php?user=Atom%20Hotel&ip=203.0.113.10');
+});
+
+test('recaptcha rejects unsuccessful verification responses', function () {
+    setSetting('google_recaptcha_enabled', '1');
+    Http::fake([
+        'google.com/recaptcha/*' => Http::response(['success' => false]),
+    ]);
+    $failure = null;
+
+    (new GoogleRecaptchaRule)('g-recaptcha-response', 'invalid-token', function (string $message) use (&$failure): void {
+        $failure = $message;
+    });
+
+    expect($failure)->not->toBeNull();
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && $request->url() === 'https://www.google.com/recaptcha/api/siteverify'
+        && $request['response'] === 'invalid-token');
+});
+
+test('IP reputation lookups validate addresses and handle upstream failure', function () {
+    Http::fake([
+        'api.ipdata.co/*' => Http::response(['message' => 'rate limited'], 429),
+    ]);
+    $lookups = app(IpLookupService::class);
+
+    expect($lookups->ipLookup('not-an-ip', 'secret'))
+        ->toBe(['message' => 'Invalid IP address.', 'status' => 422])
+        ->and($lookups->ipLookup('203.0.113.10', 'secret'))
+        ->toBe(['message' => 'rate limited', 'status' => 429]);
+
+    Http::assertSentCount(3);
+});
+
+test('discord failures log only status metadata and throw a retryable error', function () {
+    setSetting('discord_webhook_url', 'https://discord.com/api/webhooks/123/token_value');
+    Http::fake([
+        'discord.com/*' => Http::response('sensitive response body', 500),
+    ]);
+    Log::spy();
+
+    $job = new SendRegisteredUserWebhook('Tester', '203.0.113.10', 'tester@example.com');
+
+    expect(fn () => $job->handle())
+        ->toThrow(RuntimeException::class, 'Discord registration webhook delivery failed.');
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->with('Discord registration webhook returned an error.', ['status' => 500]);
+});


### PR DESCRIPTION
## Summary
- enforce TLS verification, connection and response timeouts, and bounded retries for external HTTP calls
- restrict registration webhooks to official Discord HTTPS endpoints and remove sensitive values from failure logs
- inject lookup services and preserve explicit fail-open or fail-closed behavior per integration
- cover URL validation, request encoding, upstream failures, and sanitized webhook logging

## Verification
- `vendor/bin/pest` - 146 passed, 416 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test app/Support/OutboundHttp.php app/Support/DiscordWebhookUrl.php app/Services/FindRetrosService.php app/Http/Middleware/FindRetrosMiddleware.php app/Services/IpLookupService.php app/Http/Middleware/VPNCheckerMiddleware.php app/Rules/GoogleRecaptchaRule.php app/Jobs/SendRegisteredUserWebhook.php tests/Feature/Services/OutboundHttpTest.php`
- `git diff --cached --check`