### PR TITLE
fix: centralize ticket authorization

### DIFF
--- a/app/Http/Controllers/Help/TicketReplyController.php
+++ b/app/Http/Controllers/Help/TicketReplyController.php
@@ -6,22 +6,13 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\WebsiteTicketReplyFormRequest;
 use App\Models\Help\WebsiteHelpCenterTicket;
 use App\Models\Help\WebsiteHelpCenterTicketReply;
+use Illuminate\Http\RedirectResponse;
 
 class TicketReplyController extends Controller
 {
-    public function store(WebsiteHelpCenterTicket $ticket, WebsiteTicketReplyFormRequest $request)
+    public function store(WebsiteHelpCenterTicket $ticket, WebsiteTicketReplyFormRequest $request): RedirectResponse
     {
-        if (! $ticket->isOpen()) {
-            return redirect()->back()->with([
-                'message' => __('You cannot reply to the ticket as it has been closed.'),
-            ]);
-        }
-
-        if (! $ticket->canManageTicket()) {
-            return redirect()->back()->with([
-                'message' => __('You cannot reply to others tickets.'),
-            ]);
-        }
+        $this->authorize('reply', $ticket);
 
         $data = $request->validated();
         $ticket->replies()->create([
@@ -32,13 +23,9 @@ class TicketReplyController extends Controller
         return redirect()->back()->with('success', __('The reply has been submitted!'));
     }
 
-    public function destroy(WebsiteHelpCenterTicketReply $reply)
+    public function destroy(WebsiteHelpCenterTicketReply $reply): RedirectResponse
     {
-        if (! $reply->canDeleteReply()) {
-            return redirect()->back()->with([
-                'message' => __('You do not have permission to delete this reply.'),
-            ]);
-        }
+        $this->authorize('delete', $reply);
 
         $reply->delete();
 

--- a/app/Models/Help/WebsiteHelpCenterTicket.php
+++ b/app/Models/Help/WebsiteHelpCenterTicket.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\Auth;
 use Stevebauman\Purify\Facades\Purify;
 
 /**
@@ -57,26 +56,6 @@ class WebsiteHelpCenterTicket extends Model
     public function replies(): HasMany
     {
         return $this->hasMany(WebsiteHelpCenterTicketReply::class, 'ticket_id');
-    }
-
-    public function canDeleteTicket()
-    {
-        return $this->user_id === Auth::id() || hasPermission('delete_website_tickets');
-    }
-
-    public function canManageTicket()
-    {
-        return $this->user_id === Auth::id() || hasPermission('manage_website_tickets');
-    }
-
-    public function canCloseTicket()
-    {
-        return $this->user_id === Auth::id() || hasPermission('manage_website_tickets');
-    }
-
-    public function isOpen()
-    {
-        return $this->open || hasPermission('manage_website_tickets');
     }
 
     public function getContentAttribute($value)

--- a/app/Models/Help/WebsiteHelpCenterTicketReply.php
+++ b/app/Models/Help/WebsiteHelpCenterTicketReply.php
@@ -6,7 +6,6 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
 use Stevebauman\Purify\Facades\Purify;
 
 /**
@@ -43,11 +42,6 @@ class WebsiteHelpCenterTicketReply extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
-    }
-
-    public function canDeleteReply()
-    {
-        return $this->user_id === Auth::id() || hasPermission('delete_website_ticket_replies');
     }
 
     public function getContentAttribute($value)

--- a/app/Policies/WebsiteHelpCenterTicketPolicy.php
+++ b/app/Policies/WebsiteHelpCenterTicketPolicy.php
@@ -4,18 +4,21 @@ namespace App\Policies;
 
 use App\Models\Help\WebsiteHelpCenterTicket;
 use App\Models\User;
+use App\Services\PermissionsService;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class WebsiteHelpCenterTicketPolicy
 {
     use HandlesAuthorization;
 
+    public function __construct(private readonly PermissionsService $permissions) {}
+
     /**
      * The ticket overview lists every user's tickets, so it is staff-only.
      */
     public function viewAny(User $user): bool
     {
-        return hasPermission('manage_website_tickets');
+        return $this->permissions->allows($user, 'manage_website_tickets');
     }
 
     public function view(User $user, WebsiteHelpCenterTicket $ticket): bool
@@ -25,11 +28,18 @@ class WebsiteHelpCenterTicketPolicy
 
     public function update(User $user, WebsiteHelpCenterTicket $ticket): bool
     {
-        return $ticket->user_id === $user->id || hasPermission('manage_website_tickets');
+        return $ticket->user_id === $user->id
+            || $this->permissions->allows($user, 'manage_website_tickets');
     }
 
     public function delete(User $user, WebsiteHelpCenterTicket $ticket): bool
     {
-        return $ticket->user_id === $user->id || hasPermission('delete_website_tickets');
+        return $ticket->user_id === $user->id
+            || $this->permissions->allows($user, 'delete_website_tickets');
+    }
+
+    public function reply(User $user, WebsiteHelpCenterTicket $ticket): bool
+    {
+        return (bool) $ticket->open && $this->update($user, $ticket);
     }
 }

--- a/app/Policies/WebsiteHelpCenterTicketReplyPolicy.php
+++ b/app/Policies/WebsiteHelpCenterTicketReplyPolicy.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Help\WebsiteHelpCenterTicketReply;
+use App\Models\User;
+use App\Services\PermissionsService;
+
+class WebsiteHelpCenterTicketReplyPolicy
+{
+    public function __construct(private readonly PermissionsService $permissions) {}
+
+    public function delete(User $user, WebsiteHelpCenterTicketReply $reply): bool
+    {
+        return $reply->user_id === $user->id
+            || $this->permissions->allows($user, 'delete_website_ticket_replies');
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -3,7 +3,11 @@
 namespace App\Providers;
 
 // use Illuminate\Support\Facades\Gate;
+use App\Models\Help\WebsiteHelpCenterTicket;
+use App\Models\Help\WebsiteHelpCenterTicketReply;
 use App\Policies\ActivityPolicy;
+use App\Policies\WebsiteHelpCenterTicketPolicy;
+use App\Policies\WebsiteHelpCenterTicketReplyPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Spatie\Activitylog\Models\Activity;
 
@@ -17,6 +21,8 @@ class AuthServiceProvider extends ServiceProvider
     protected $policies = [
         // 'App\Models\Model' => 'App\Policies\ModelPolicy',
         Activity::class => ActivityPolicy::class,
+        WebsiteHelpCenterTicket::class => WebsiteHelpCenterTicketPolicy::class,
+        WebsiteHelpCenterTicketReply::class => WebsiteHelpCenterTicketReplyPolicy::class,
     ];
 
     /**

--- a/app/Services/PermissionsService.php
+++ b/app/Services/PermissionsService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Miscellaneous\WebsitePermission;
+use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -21,10 +22,17 @@ class PermissionsService
 
     public function getOrDefault(string $permissionName, bool $default = false): bool
     {
+        $user = auth()->user();
+
+        return $user instanceof User && $this->allows($user, $permissionName, $default);
+    }
+
+    public function allows(User $user, string $permissionName, bool $default = false): bool
+    {
         if (! $this->permissions->has($permissionName)) {
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $this->permissions->get($permissionName);
+        return $user->rank >= (int) $this->permissions->get($permissionName);
     }
 }

--- a/resources/views/help-center/tickets/show.blade.php
+++ b/resources/views/help-center/tickets/show.blade.php
@@ -6,18 +6,18 @@
            <div class="flex gap-x-2">
                {{ $ticket->title }} [{{ $ticket->category->name }}]
 
-               @if($ticket->canManageTicket())
+               @can('update', $ticket)
                    <a data-turbolinks="false" href="{{ route('help-center.ticket.edit', $ticket) }}">
                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
                            <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" />
                        </svg>
                    </a>
-               @endif
+               @endcan
            </div>
         </x-slot:title>
 
         <div class="w-full flex gap-x-3">
-            @if($ticket->isOpen())
+            @if($ticket->open)
                 <form action="{{ route('help-center.ticket.toggle-status', $ticket) }}" method="POST" class="w-full">
                     @method('PUT')
                     @csrf
@@ -37,14 +37,16 @@
                 </form>
             @endif
 
-            <form action="{{ route('help-center.ticket.destroy', $ticket) }}" method="POST" class="w-full">
-                @method('DELETE')
-                @csrf
+            @can('delete', $ticket)
+                <form action="{{ route('help-center.ticket.destroy', $ticket) }}" method="POST" class="w-full">
+                    @method('DELETE')
+                    @csrf
 
-                <x-form.danger-button>
-                    Delete
-                </x-form.danger-button>
-            </form>
+                    <x-form.danger-button>
+                        Delete
+                    </x-form.danger-button>
+                </form>
+            @endcan
         </div>
 
         <article class="prose-xl mt-8" style="width: 100%;">
@@ -97,7 +99,7 @@
             {{ __('Please submit your reply below') }}
         </x-slot:under-title>
 
-        @if($ticket->isOpen())
+        @if($ticket->open)
             <form action="{{ route('help-center.ticket.reply.store', $ticket) }}" method="POST">
                 @csrf
 
@@ -124,7 +126,7 @@
                             <div class="flex gap-x-2">
                                 <small class="text-gray-400">{{ $reply->created_at->diffForHumans() }}</small>
 
-                                @if($reply->user_id === Auth::id() || hasPermission('delete_website_ticket_replies'))
+                                @can('delete', $reply)
                                     <form action="{{ route('help-center.ticket.reply.destroy', $reply) }}" method="POST">
                                         @method('DELETE')
                                         @csrf
@@ -135,7 +137,7 @@
                                             </svg>
                                         </button>
                                     </form>
-                                @endif
+                                @endcan
                             </div>
                         </div>
 
@@ -147,16 +149,18 @@
                     <div class="w-full rounded bg-gray-200 dark:bg-gray-700">
                         <div class="h-[50px] px-4 flex items-center justify-between border-b border-gray-300 dark:border-gray-800 relative overflow-hidden">
                             <div class="flex gap-x-2">
-                                <form action="{{ route('help-center.ticket.reply.destroy', $reply) }}" method="POST">
-                                    @method('DELETE')
-                                    @csrf
+                                @can('delete', $reply)
+                                    <form action="{{ route('help-center.ticket.reply.destroy', $reply) }}" method="POST">
+                                        @method('DELETE')
+                                        @csrf
 
-                                    <button type="submit">
-                                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
-                                        </svg>
-                                    </button>
-                                </form>
+                                        <button type="submit">
+                                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
+                                            </svg>
+                                        </button>
+                                    </form>
+                                @endcan
 
                                 <small class="text-gray-400">{{ $reply->created_at->diffForHumans() }}</small>
                             </div>

--- a/tests/Feature/Help/TicketFlowTest.php
+++ b/tests/Feature/Help/TicketFlowTest.php
@@ -66,6 +66,64 @@ test('a user can reply to their ticket', function () {
     expect($ticket->replies()->count())->toBe(1);
 });
 
+test('a user cannot reply to another users ticket', function () {
+    $ticket = createTicket($this->user);
+    $stranger = User::factory()->create(['rank' => 1]);
+
+    $this->actingAs($stranger)
+        ->post(route('help-center.ticket.reply.store', $ticket), [
+            'content' => 'I should not be able to post this reply.',
+        ])
+        ->assertForbidden();
+
+    expect($ticket->replies()->count())->toBe(0);
+});
+
+test('a user cannot reply to a closed ticket', function () {
+    $ticket = createTicket($this->user);
+    $ticket->update(['open' => false]);
+
+    $this->actingAs($this->user)
+        ->post(route('help-center.ticket.reply.store', $ticket), [
+            'content' => 'I should not be able to post this reply.',
+        ])
+        ->assertForbidden();
+
+    expect($ticket->replies()->count())->toBe(0);
+});
+
+test('a user cannot delete another users reply', function () {
+    $ticket = createTicket($this->user);
+    $reply = $ticket->replies()->create([
+        'user_id' => $this->user->id,
+        'content' => 'This reply belongs to the ticket owner.',
+    ]);
+    $stranger = User::factory()->create(['rank' => 1]);
+
+    $this->actingAs($stranger)
+        ->delete(route('help-center.ticket.reply.destroy', $reply))
+        ->assertForbidden();
+
+    expect($reply->fresh())->not->toBeNull();
+});
+
+test('authorized staff can view and reply to another users ticket', function () {
+    $ticket = createTicket($this->user);
+    $staff = User::factory()->create(['rank' => 7]);
+
+    $this->actingAs($staff)
+        ->get(route('help-center.ticket.show', $ticket))
+        ->assertOk();
+
+    $this->actingAs($staff)
+        ->post(route('help-center.ticket.reply.store', $ticket), [
+            'content' => 'A staff response to the ticket owner.',
+        ])
+        ->assertSessionHas('success');
+
+    expect($ticket->replies()->where('user_id', $staff->id)->exists())->toBeTrue();
+});
+
 test('the ticket overview is staff-only', function () {
     $this->actingAs($this->user)->get(route('help-center.ticket.index'))->assertForbidden();
 });


### PR DESCRIPTION
## Summary
- move ticket and reply authorization out of Eloquent models into policies
- enforce ownership, staff permissions, and closed-ticket rules in controllers
- align ticket and reply controls with the same policy decisions
- make permission checks accept an explicit user

## Verification
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test app/Http/Controllers/Help/TicketReplyController.php app/Models/Help/WebsiteHelpCenterTicket.php app/Models/Help/WebsiteHelpCenterTicketReply.php app/Policies/WebsiteHelpCenterTicketPolicy.php app/Policies/WebsiteHelpCenterTicketReplyPolicy.php app/Providers/AuthServiceProvider.php app/Services/PermissionsService.php tests/Feature/Help/TicketFlowTest.php`
- `npx prettier resources/views/help-center/tickets/show.blade.php --check`