### PR TITLE
fix: sanitize rich text before persistence

### DIFF
--- a/app/Casts/PurifiedHtml.php
+++ b/app/Casts/PurifiedHtml.php
@@ -7,8 +7,8 @@ use Illuminate\Database\Eloquent\Model;
 use Stevebauman\Purify\Facades\Purify;
 
 /**
- * Sanitises rich-text HTML on read, so stored editor content (including legacy
- * rows) is safe wherever it is rendered with {!! !!}.
+ * Sanitises rich-text HTML before persistence so every read surface receives
+ * the same safe value without repeatedly running HTML Purifier.
  *
  * @implements CastsAttributes<string|null, string|null>
  */
@@ -16,11 +16,11 @@ class PurifiedHtml implements CastsAttributes
 {
     public function get(Model $model, string $key, mixed $value, array $attributes): ?string
     {
-        return $value === null ? null : Purify::clean($value);
+        return $value === null ? null : (string) $value;
     }
 
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed
     {
-        return $value;
+        return $value === null ? null : Purify::clean((string) $value);
     }
 }

--- a/app/Models/Help/WebsiteHelpCenterTicket.php
+++ b/app/Models/Help/WebsiteHelpCenterTicket.php
@@ -2,13 +2,13 @@
 
 namespace App\Models\Help;
 
+use App\Casts\PurifiedHtml;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Auth;
-use Stevebauman\Purify\Facades\Purify;
 
 /**
  * @property int $id
@@ -44,6 +44,13 @@ class WebsiteHelpCenterTicket extends Model
 
     public $timestamps = false;
 
+    protected function casts(): array
+    {
+        return [
+            'content' => PurifiedHtml::class,
+        ];
+    }
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
@@ -77,10 +84,5 @@ class WebsiteHelpCenterTicket extends Model
     public function isOpen()
     {
         return $this->open || hasPermission('manage_website_tickets');
-    }
-
-    public function getContentAttribute($value)
-    {
-        return Purify::clean($value);
     }
 }

--- a/app/Models/Help/WebsiteHelpCenterTicketReply.php
+++ b/app/Models/Help/WebsiteHelpCenterTicketReply.php
@@ -2,12 +2,12 @@
 
 namespace App\Models\Help;
 
+use App\Casts\PurifiedHtml;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
-use Stevebauman\Purify\Facades\Purify;
 
 /**
  * @property int $id
@@ -35,6 +35,13 @@ class WebsiteHelpCenterTicketReply extends Model
 {
     protected $guarded = ['id'];
 
+    protected function casts(): array
+    {
+        return [
+            'content' => PurifiedHtml::class,
+        ];
+    }
+
     public function ticket(): BelongsTo
     {
         return $this->belongsTo(WebsiteHelpCenterTicket::class, 'ticket_id');
@@ -48,10 +55,5 @@ class WebsiteHelpCenterTicketReply extends Model
     public function canDeleteReply()
     {
         return $this->user_id === Auth::id() || hasPermission('delete_website_ticket_replies');
-    }
-
-    public function getContentAttribute($value)
-    {
-        return Purify::clean($value);
     }
 }

--- a/database/migrations/2026_07_16_020000_sanitize_stored_rich_text.php
+++ b/database/migrations/2026_07_16_020000_sanitize_stored_rich_text.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Stevebauman\Purify\Facades\Purify;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->sanitizeColumn('website_articles', 'full_story');
+        $this->sanitizeColumn('website_help_center_categories', 'content');
+        $this->sanitizeColumn('website_help_center_tickets', 'content');
+        $this->sanitizeColumn('website_help_center_ticket_replies', 'content');
+    }
+
+    public function down(): void
+    {
+        // Sanitization is intentionally irreversible; unsafe markup is discarded.
+    }
+
+    private function sanitizeColumn(string $table, string $column): void
+    {
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, $column)) {
+            return;
+        }
+
+        DB::table($table)
+            ->select(['id', $column])
+            ->whereNotNull($column)
+            ->chunkById(100, function ($rows) use ($table, $column): void {
+                foreach ($rows as $row) {
+                    $value = (string) $row->{$column};
+                    $sanitized = Purify::clean($value);
+
+                    if ($sanitized !== $value) {
+                        DB::table($table)
+                            ->where('id', $row->id)
+                            ->update([$column => $sanitized]);
+                    }
+                }
+            });
+    }
+};

--- a/tests/Feature/Help/TicketFlowTest.php
+++ b/tests/Feature/Help/TicketFlowTest.php
@@ -3,6 +3,7 @@
 use App\Models\Help\WebsiteHelpCenterCategory;
 use App\Models\Help\WebsiteHelpCenterTicket;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 
 function createTicket(User $user): WebsiteHelpCenterTicket
 {
@@ -33,6 +34,26 @@ test('a user can submit a ticket', function () {
         ->assertSessionHas('success');
 
     expect($this->user->tickets()->count())->toBe(1);
+});
+
+test('ticket rich text is sanitized before it is stored', function () {
+    $category = WebsiteHelpCenterCategory::firstOrCreate(['name' => 'General'], ['content' => 'General questions']);
+
+    $this->actingAs($this->user)
+        ->post(route('help-center.ticket.store'), [
+            'category_id' => $category->id,
+            'title' => 'Something unsafe happened',
+            'content' => '<p>A useful description.</p><script>alert("unsafe")</script>',
+        ])
+        ->assertSessionHas('success');
+
+    $storedContent = DB::table('website_help_center_tickets')
+        ->where('user_id', $this->user->id)
+        ->value('content');
+
+    expect($storedContent)
+        ->toContain('<p>A useful description.</p>')
+        ->not->toContain('<script>');
 });
 
 test('a user can view and close their own ticket', function () {


### PR DESCRIPTION
## Summary
- sanitize rich text through the shared Eloquent cast before database writes
- move ticket and reply content onto the shared cast
- clean legacy article and help-center HTML in an idempotent chunked migration
- verify unsafe markup is absent from raw ticket storage

## Verification
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test app/Casts/PurifiedHtml.php app/Models/Help/WebsiteHelpCenterTicket.php app/Models/Help/WebsiteHelpCenterTicketReply.php database/migrations/2026_07_16_020000_sanitize_stored_rich_text.php tests/Feature/Help/TicketFlowTest.php`