### PR TITLE
test: isolate the PHPUnit environment

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,7 +1,7 @@
 APP_NAME=Atom
 APP_ENV=testing
-APP_KEY=base64:GENERATE_NEW_KEY_HERE
-APP_DEBUG=true
+APP_KEY=base64:dGVzdGluZy10ZXN0aW5nLXRlc3RpbmctdGVzdGluZy0=
+APP_DEBUG=false
 APP_URL=http://localhost
 
 LOG_CHANNEL=stack
@@ -12,7 +12,7 @@ DB_CONNECTION=mariadb
 DB_HOST=127.0.0.1
 DB_PORT=3306
 DB_DATABASE=testing
-DB_USERNAME=docker
+DB_USERNAME=root
 DB_PASSWORD=password
 
 BROADCAST_DRIVER=log

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,9 +9,15 @@
   <php>
     <env name="APP_ENV" value="testing"/>
     <env name="APP_KEY" value="base64:dGVzdGluZy10ZXN0aW5nLXRlc3RpbmctdGVzdGluZy0="/>
+    <env name="APP_DEBUG" value="false"/>
     <env name="BCRYPT_ROUNDS" value="4"/>
     <env name="CACHE_DRIVER" value="array"/>
+    <env name="DB_CONNECTION" value="mariadb"/>
+    <env name="DB_HOST" value="127.0.0.1"/>
+    <env name="DB_PORT" value="3306"/>
     <env name="DB_DATABASE" value="testing"/>
+    <env name="DB_USERNAME" value="root"/>
+    <env name="DB_PASSWORD" value="password"/>
     <env name="MAIL_MAILER" value="array"/>
     <env name="QUEUE_CONNECTION" value="sync"/>
     <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
## Summary
- pin PHPUnit to the dedicated local MariaDB test database
- prevent test runs from inheriting debug and database routing from `.env`
- align the testing environment template with PHPUnit and CI credentials
- retain CI job-level environment overrides

## Verification
- `xmllint --noout phpunit.xml`
- `vendor/bin/pest`