### PR TITLE
fix: make test schema imports fail fast

### DIFF
--- a/database/migrations/2014_01_01_000000_core_sql_file.php
+++ b/database/migrations/2014_01_01_000000_core_sql_file.php
@@ -3,89 +3,44 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Output\ConsoleOutput;
 
 class CoreSqlFile extends Migration
 {
-    /**
-     * Run the migrations.
-     *
-     * @return void
-     */
-    public function up()
+    public function up(): void
     {
-        // Only run in testing environment
-        if (app()->environment() !== 'testing') {
+        if (! app()->environment('testing') || Schema::hasTable('users')) {
             return;
         }
 
-        ini_set('memory_limit', '-1');
+        $path = database_path('migrations/sqls/default.sql');
 
-        if (! Schema::hasTable('users')) {
-            $output = new ConsoleOutput;
-            $output->writeln("\n🚀 Running Core SQL File Migration...");
+        if (! is_readable($path)) {
+            throw new RuntimeException('Unable to read the core SQL schema.');
+        }
 
-            // Set charset to support emojis
-            DB::statement('SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci');
+        $file = new SplFileObject($path);
+        $statement = '';
 
-            $sqlFile = database_path('migrations/sqls/default.sql');
-            $sql = file_get_contents($sqlFile);
+        foreach ($file as $line) {
+            $statement .= $line;
 
-            // Split into individual statements to show progress
-            $statements = array_filter(
-                preg_split('/;\s*\n/', $sql),
-                fn ($stmt) => ! empty(trim($stmt)) &&
-                           ! str_starts_with(trim($stmt), '--') &&
-                           ! str_starts_with(trim($stmt), '/*'),
-            );
-
-            $totalStatements = count($statements);
-            $output->writeln("📊 Processing $totalStatements SQL statements...");
-
-            $progressBar = new ProgressBar($output, $totalStatements);
-            $progressBar->setFormat(' %current%/%max% [%bar%] %percent:3s%% %message%');
-            $progressBar->setMessage('Starting...');
-            $progressBar->start();
-
-            foreach ($statements as $index => $statement) {
-                $statement = trim($statement);
-
-                if (! empty($statement)) {
-                    try {
-                        DB::unprepared($statement);
-
-                        // Update progress message based on statement type
-                        if (str_contains($statement, 'CREATE TABLE')) {
-                            preg_match('/CREATE TABLE\s+`?(\w+)`?/i', $statement, $matches);
-                            $tableName = $matches[1] ?? 'unknown';
-                            $progressBar->setMessage("Created table: $tableName");
-                        } elseif (str_contains($statement, 'INSERT INTO')) {
-                            $progressBar->setMessage('Inserting data...');
-                        } else {
-                            $progressBar->setMessage('Processing...');
-                        }
-
-                    } catch (Exception $e) {
-                        $progressBar->setMessage('Error: ' . substr($e->getMessage(), 0, 50) . '...');
-                        // Continue on non-critical errors
-                    }
-                }
-
-                $progressBar->advance();
-
-                // Small delay to make progress visible
-                if ($index % 100 === 0) {
-                    usleep(1000); // 1ms
-                }
+            if (! str_ends_with(rtrim($line), ';')) {
+                continue;
             }
 
-            $progressBar->setMessage('✅ Complete!');
-            $progressBar->finish();
-            $output->writeln("\n🎉 Core SQL schema imported successfully!");
-        } else {
-            $output = new ConsoleOutput;
-            $output->writeln('ℹ️  Core tables already exist, skipping SQL import.');
+            DB::unprepared($statement);
+            $statement = '';
         }
+
+        if (trim($statement) !== '') {
+            throw new RuntimeException('The core SQL schema ends with an incomplete statement.');
+        }
+
+        DB::statement('SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci');
+    }
+
+    public function down(): void
+    {
+        // The emulator owns this imported schema, so Laravel must not drop it.
     }
 }

--- a/database/migrations/2022_08_06_022347_add_referral_code_to_users_table.php
+++ b/database/migrations/2022_08_06_022347_add_referral_code_to_users_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use App\Models\User;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -16,9 +16,14 @@ return new class extends Migration
             });
         }
 
-        foreach (User::whereNull('referral_code')->get() as $user) {
-            $user->update(['referral_code' => sprintf('%s%s', $user->id, Str::random(8))]);
-        }
+        DB::table('users')
+            ->whereNull('referral_code')
+            ->orderBy('id')
+            ->eachById(function (object $user) {
+                DB::table('users')
+                    ->where('id', $user->id)
+                    ->update(['referral_code' => sprintf('%s%s', $user->id, Str::random(8))]);
+            });
     }
 
     public function down(): void

--- a/database/seeders/TestingSeeder.php
+++ b/database/seeders/TestingSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Miscellaneous\WebsiteInstallation;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class TestingSeeder extends Seeder
@@ -14,6 +15,8 @@ class TestingSeeder extends Seeder
      */
     public function run(): void
     {
+        DB::table('users')->delete();
+
         WebsiteInstallation::query()->firstOrCreate(['installation_key' => 'key'], ['completed' => true]);
 
         $this->call([


### PR DESCRIPTION
## Summary
- stream the core SQL dump statement by statement without loading it all into memory
- fail immediately on unreadable, incomplete, or invalid SQL instead of suppressing every database error
- remove unlimited-memory changes, artificial delays, and migration console side effects
- restore the connection to utf8mb4 after the legacy dump changes its session charset
- use the query builder for referral backfills so migrations do not cache an incomplete User schema
- explicitly remove the bundled system account from the deterministic test fixture

## Stack
- depends on #114, which hardens the rest of the migration chain

## Verification
- full `migrate:fresh` against MariaDB
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `vendor/bin/pint --test` on changed PHP files
