### PR TITLE
refactor: analyze the complete filament admin

### DIFF
--- a/app/Filament/Pages/BadgePage.php
+++ b/app/Filament/Pages/BadgePage.php
@@ -32,8 +32,9 @@ class BadgePage extends Page
 
     protected static string $translateIdentifier = 'badge-resource';
 
-    public $badgeWasPreviouslyCreated;
+    public bool $badgeWasPreviouslyCreated = false;
 
+    /** @var array<string, mixed> */
     public ?array $data = [];
 
     public static string $roleName = 'badge_page';
@@ -69,7 +70,7 @@ class BadgePage extends Page
                             ->label(__('filament::resources.inputs.badge_image'))
                             ->placeholder('...')
                             ->autocomplete()
-                            ->visible(fn (Get $get) => isset($this->data['image']) ?? false)
+                            ->visible(fn (Get $get) => isset($this->data['image']))
                             ->prefixAction(
                                 fn (?string $state): PageAction => PageAction::make('visit')
                                     ->icon('heroicon-s-arrow-top-right-on-square')
@@ -87,12 +88,12 @@ class BadgePage extends Page
                         TextInput::make('nitro.title')
                             ->label(__('filament::resources.inputs.badge_title'))
                             ->placeholder('...')
-                            ->visible(fn () => isset($this->data['nitro']['title']) ?? false),
+                            ->visible(fn () => isset($this->data['nitro']['title'])),
 
                         TextInput::make('nitro.description')
                             ->label(__('filament::resources.inputs.badge_description'))
                             ->placeholder('...')
-                            ->visible(fn () => isset($this->data['nitro']['description']) ?? false),
+                            ->visible(fn () => isset($this->data['nitro']['description'])),
                     ]),
 
                 Section::make('Flash Texts')
@@ -102,12 +103,12 @@ class BadgePage extends Page
                         TextInput::make('flash.title')
                             ->label(__('filament::resources.inputs.badge_title'))
                             ->placeholder('...')
-                            ->visible(fn () => isset($this->data['flash']['title']) ?? false),
+                            ->visible(fn () => isset($this->data['flash']['title'])),
 
                         TextInput::make('flash.description')
                             ->label(__('filament::resources.inputs.badge_description'))
                             ->placeholder('...')
-                            ->visible(fn () => isset($this->data['flash']['description']) ?? false),
+                            ->visible(fn () => isset($this->data['flash']['description'])),
                     ]),
             ])
             ->statePath('data');
@@ -115,10 +116,13 @@ class BadgePage extends Page
 
     private function searchBadgesByCode(): void
     {
-        $badgeCode = $this->form->getState()['code'] ?? null;
+        $badgeCode = $this->data['code'] ?? null;
 
         if (empty($badgeCode)) {
-            $this->notify('danger', __('filament::resources.notifications.badge_code_required'));
+            Notification::make()
+                ->danger()
+                ->title(__('filament::resources.notifications.badge_code_required'))
+                ->send();
 
             return;
         }

--- a/app/Filament/Resources/Atom/Articles/ArticleResource.php
+++ b/app/Filament/Resources/Atom/Articles/ArticleResource.php
@@ -206,6 +206,7 @@ class ArticleResource extends Resource
 
     public static function getGlobalSearchEloquentQuery(): Builder
     {
-        return parent::getGlobalSearchEloquentQuery()->withTrashed();
+        return parent::getGlobalSearchEloquentQuery()
+            ->withoutGlobalScope(SoftDeletingScope::class);
     }
 }

--- a/app/Filament/Resources/Atom/Articles/Pages/EditArticle.php
+++ b/app/Filament/Resources/Atom/Articles/Pages/EditArticle.php
@@ -3,11 +3,13 @@
 namespace App\Filament\Resources\Atom\Articles\Pages;
 
 use App\Filament\Resources\Atom\Articles\ArticleResource;
+use App\Models\Articles\WebsiteArticle;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use LogicException;
 
 class EditArticle extends EditRecord
 {
@@ -22,18 +24,26 @@ class EditArticle extends EditRecord
 
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
+        if (! $record instanceof WebsiteArticle) {
+            throw new LogicException('The article editor received an unsupported model.');
+        }
+
         $isVisible = (bool) Arr::pull($data, 'is_visible', true);
 
         return DB::transaction(function () use ($record, $data, $isVisible): Model {
-            $record = parent::handleRecordUpdate($record, $data);
+            $updatedRecord = parent::handleRecordUpdate($record, $data);
 
-            if ($isVisible && $record->trashed()) {
-                $record->restore();
-            } elseif (! $isVisible && ! $record->trashed()) {
-                $record->delete();
+            if (! $updatedRecord instanceof WebsiteArticle) {
+                throw new LogicException('The article editor updated an unsupported model.');
             }
 
-            return $record;
+            if ($isVisible && $updatedRecord->trashed()) {
+                $updatedRecord->restore();
+            } elseif (! $isVisible && ! $updatedRecord->trashed()) {
+                $updatedRecord->delete();
+            }
+
+            return $updatedRecord;
         });
     }
 }

--- a/app/Filament/Resources/Atom/Articles/RelationManagers/TagsRelationManager.php
+++ b/app/Filament/Resources/Atom/Articles/RelationManagers/TagsRelationManager.php
@@ -18,6 +18,8 @@ class TagsRelationManager extends RelationManager
 {
     use TranslatableResource;
 
+    protected static string|\UnitEnum|null $navigationGroup = null;
+
     protected static string $relationship = 'tags';
 
     protected static ?string $recordTitleAttribute = 'name';

--- a/app/Filament/Resources/Atom/Permissions/PermissionResource.php
+++ b/app/Filament/Resources/Atom/Permissions/PermissionResource.php
@@ -25,7 +25,6 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Columns\ToggleColumn;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\HtmlString;
 use Str;
@@ -262,9 +261,9 @@ class PermissionResource extends Resource
 
                 TextColumn::make('rank_name')
                     ->label(__('filament::resources.columns.name'))
-                    ->description(fn (Model $record) => Str::limit($record->description, 40))
-                    ->tooltip(function (Model $record): ?string {
-                        $description = $record->description;
+                    ->description(fn (Permission $record) => Str::limit($record->job_description, 40))
+                    ->tooltip(function (Permission $record): ?string {
+                        $description = $record->job_description;
 
                         if (strlen($description) <= 40) {
                             return null;
@@ -276,7 +275,7 @@ class PermissionResource extends Resource
 
                 TextColumn::make('prefix')
                     ->label(__('filament::resources.columns.prefix'))
-                    ->description(fn (Model $record) => $record->prefix_color)
+                    ->description(fn (Permission $record) => $record->prefix_color)
                     ->searchable(),
 
                 ToggleColumn::make('hidden_rank')

--- a/app/Filament/Resources/Atom/Tags/RelationManagers/ArticlesRelationManager.php
+++ b/app/Filament/Resources/Atom/Tags/RelationManagers/ArticlesRelationManager.php
@@ -16,6 +16,8 @@ class ArticlesRelationManager extends RelationManager
 {
     use TranslatableResource;
 
+    protected static string|\UnitEnum|null $navigationGroup = null;
+
     // Use camelCase to match the method in the Tag model
     protected static string $relationship = 'websiteArticles';
 

--- a/app/Filament/Resources/Atom/Teams/TeamResource.php
+++ b/app/Filament/Resources/Atom/Teams/TeamResource.php
@@ -18,7 +18,6 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
-use Illuminate\Database\Eloquent\Model;
 
 class TeamResource extends Resource
 {
@@ -80,7 +79,7 @@ class TeamResource extends Resource
 
                 IconColumn::make('hidden_rank')
                     ->label(__('filament::resources.columns.is_hidden'))
-                    ->icon(fn (Model $record) => $record->hidden_rank ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                    ->icon(fn (WebsiteTeam $record) => $record->hidden_rank ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
                     ->colors([
                         'danger' => false,
                         'success' => true,

--- a/app/Filament/Resources/Home/HomeCategoryResource.php
+++ b/app/Filament/Resources/Home/HomeCategoryResource.php
@@ -15,8 +15,8 @@ use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
-use Livewire\Component;
 
 class HomeCategoryResource extends Resource
 {
@@ -58,11 +58,11 @@ class HomeCategoryResource extends Resource
             ->columns([
                 TextColumn::make('id')
                     ->label(__('filament::resources.columns.id'))
-                    ->visible(fn (Component $livewire): bool => ! $livewire->isTableReordering),
+                    ->visible(fn (HasTable $livewire): bool => ! $livewire->isTableReordering()),
 
                 TextColumn::make('order')
                     ->label(__('filament::resources.columns.order'))
-                    ->visible(fn (Component $livewire): bool => $livewire->isTableReordering),
+                    ->visible(fn (HasTable $livewire): bool => $livewire->isTableReordering()),
 
                 ImageColumn::make('icon')
                     ->disk('public')

--- a/app/Filament/Resources/Home/HomeCategoryResource/Pages/EditHomeCategory.php
+++ b/app/Filament/Resources/Home/HomeCategoryResource/Pages/EditHomeCategory.php
@@ -3,10 +3,10 @@
 namespace App\Filament\Resources\Home\HomeCategoryResource\Pages;
 
 use App\Filament\Resources\Home\HomeCategoryResource;
+use App\Models\Home\HomeCategory;
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
-use Illuminate\Database\Eloquent\Model;
 
 class EditHomeCategory extends EditRecord
 {
@@ -16,7 +16,7 @@ class EditHomeCategory extends EditRecord
     {
         return [
             DeleteAction::make()
-                ->action(function (Model $record): void {
+                ->action(function (HomeCategory $record): void {
                     if ($record->homeItems()->exists()) {
                         Notification::make()
                             ->danger()

--- a/app/Filament/Resources/Home/HomeItemResource.php
+++ b/app/Filament/Resources/Home/HomeItemResource.php
@@ -19,9 +19,9 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
-use Livewire\Component;
 
 class HomeItemResource extends Resource
 {
@@ -142,11 +142,11 @@ class HomeItemResource extends Resource
         return [
             TextColumn::make('id')
                 ->label(__('filament::resources.columns.id'))
-                ->visible(fn (Component $livewire): bool => ! $livewire->isTableReordering),
+                ->visible(fn (HasTable $livewire): bool => ! $livewire->isTableReordering()),
 
             TextColumn::make('order')
                 ->label(__('filament::resources.columns.order'))
-                ->visible(fn (Component $livewire): bool => $livewire->isTableReordering),
+                ->visible(fn (HasTable $livewire): bool => $livewire->isTableReordering()),
 
             ImageColumn::make('image')
                 ->disk('public')

--- a/app/Filament/Resources/Home/HomeItemResource/Pages/EditHomeItem.php
+++ b/app/Filament/Resources/Home/HomeItemResource/Pages/EditHomeItem.php
@@ -3,10 +3,10 @@
 namespace App\Filament\Resources\Home\HomeItemResource\Pages;
 
 use App\Filament\Resources\Home\HomeItemResource;
+use App\Models\Home\HomeItem;
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
-use Illuminate\Database\Eloquent\Model;
 
 class EditHomeItem extends EditRecord
 {
@@ -16,7 +16,7 @@ class EditHomeItem extends EditRecord
     {
         return [
             DeleteAction::make()
-                ->action(function (Model $record): void {
+                ->action(function (HomeItem $record): void {
                     if ($record->userHomeItems()->exists()) {
                         Notification::make()
                             ->danger()

--- a/app/Filament/Resources/Hotel/BadgeUploads/BadgeUploadResource.php
+++ b/app/Filament/Resources/Hotel/BadgeUploads/BadgeUploadResource.php
@@ -63,8 +63,7 @@ class BadgeUploadResource extends Resource
 
     public static function getFiles(): array
     {
-        $badgePath = env('BadgePath', 'badges');
-        $files = Storage::disk('local')->files($badgePath);
+        $files = Storage::disk('badges')->files();
 
         return collect($files)->map(function ($file) {
             return [

--- a/app/Filament/Resources/Hotel/BadgeUploads/Pages/ManageBadgeUploads.php
+++ b/app/Filament/Resources/Hotel/BadgeUploads/Pages/ManageBadgeUploads.php
@@ -2,11 +2,14 @@
 
 namespace App\Filament\Resources\Hotel\BadgeUploads\Pages;
 
+use App\Filament\Resources\Hotel\BadgeUploads\BadgeUploadResource;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
-use Filament\Resources\Pages\Page; // Import the Notification class
+use Filament\Resources\Pages\Page;
+use Filament\Schemas\Schema;
+use LogicException;
 
 class ManageBadgeUploads extends Page implements HasForms
 {
@@ -14,13 +17,13 @@ class ManageBadgeUploads extends Page implements HasForms
 
     public $badge_file;
 
-    protected static string $resource = 'App\Filament\Resources\Hotel\BadgeUploads\BadgeUploadResource';
+    protected static string $resource = BadgeUploadResource::class;
 
     protected string $view = 'filament.pages.manage-badge-uploads';
 
     public function mount(): void
     {
-        $this->form->fill([]);
+        $this->formSchema()->fill([]);
     }
 
     protected function getFormSchema(): array
@@ -38,11 +41,17 @@ class ManageBadgeUploads extends Page implements HasForms
 
     public function save(): void
     {
-        $data = $this->form->getState();
+        $this->formSchema()->getState();
 
         Notification::make()
             ->title('Badge uploaded successfully!')
             ->success()
             ->send();
+    }
+
+    private function formSchema(): Schema
+    {
+        return $this->getSchema('form')
+            ?? throw new LogicException('The badge upload form schema is not registered.');
     }
 }

--- a/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogItemFullForm.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogItemFullForm.php
@@ -9,7 +9,7 @@ use Filament\Schemas\Components\Grid;
 
 class CatalogItemFullForm
 {
-    /** @return array<int, Component|Forms\Components\Component> */
+    /** @return array<int, Component> */
     public static function schema(): array
     {
         return [

--- a/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogItemMassEditForm.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogItemMassEditForm.php
@@ -3,12 +3,13 @@
 namespace App\Filament\Resources\Hotel\CatalogEditors\Forms;
 
 use Filament\Forms;
+use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Grid;
 
 /** Empty fields are skipped on save so a patch-only edit doesn't trample other columns. */
 class CatalogItemMassEditForm
 {
-    /** @return array<int, Forms\Components\Component> */
+    /** @return array<int, Component> */
     public static function schema(): array
     {
         $note = 'Leave empty to keep unchanged';
@@ -41,7 +42,7 @@ class CatalogItemMassEditForm
         $updates = [];
 
         foreach (['cost_credits', 'cost_points', 'points_type', 'amount', 'order_number'] as $col) {
-            if (isset($data[$col]) && $data[$col] !== '' && $data[$col] !== null) {
+            if (isset($data[$col]) && $data[$col] !== '') {
                 $updates[$col] = (int) $data[$col];
             }
         }

--- a/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogPageForm.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogPageForm.php
@@ -4,11 +4,12 @@ namespace App\Filament\Resources\Hotel\CatalogEditors\Forms;
 
 use App\Services\Catalog\FurniIconService;
 use Filament\Forms;
+use Filament\Schemas\Components\Component;
 use Illuminate\Support\HtmlString;
 
 class CatalogPageForm
 {
-    /** @return array<int, Forms\Components\Component> */
+    /** @return array<int, Component> */
     public static function schema(): array
     {
         $icons = app(FurniIconService::class);

--- a/app/Filament/Resources/Hotel/CatalogEditors/Forms/ItemBaseForm.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Forms/ItemBaseForm.php
@@ -8,7 +8,7 @@ use Filament\Schemas\Components\Grid;
 
 class ItemBaseForm
 {
-    /** @return array<int, Component|Forms\Components\Component> */
+    /** @return array<int, Component> */
     public static function schema(): array
     {
         return [

--- a/app/Filament/Resources/Hotel/CatalogEditors/Pages/EditCatalogItem.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Pages/EditCatalogItem.php
@@ -18,6 +18,7 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Pages\Page;
 use Filament\Schemas\Schema;
 use Illuminate\Support\Collection;
+use LogicException;
 
 class EditCatalogItem extends Page implements HasForms
 {
@@ -42,10 +43,10 @@ class EditCatalogItem extends Page implements HasForms
             ->whereKey((int) $this->record->item_ids)
             ->first();
 
-        $this->catalogForm->fill(CatalogItemFullForm::fillFrom($this->record));
+        $this->catalogFormSchema()->fill(CatalogItemFullForm::fillFrom($this->record));
 
         if ($this->itemBase) {
-            $this->itemBaseForm->fill($this->itemBase->toArray());
+            $this->itemBaseFormSchema()->fill($this->itemBase->toArray());
         }
     }
 
@@ -56,7 +57,7 @@ class EditCatalogItem extends Page implements HasForms
 
     public function getTitle(): string
     {
-        return $this->record?->catalog_name
+        return $this->record->catalog_name
             ? "Edit: {$this->record->catalog_name}"
             : 'Edit catalog item';
     }
@@ -99,7 +100,7 @@ class EditCatalogItem extends Page implements HasForms
             ->label('Save catalog item')
             ->icon('heroicon-m-check')
             ->action(function (): void {
-                $data = $this->catalogForm->getState();
+                $data = $this->catalogFormSchema()->getState();
                 $this->record->update(CatalogItemFullForm::castForSave($data));
 
                 Notification::make()
@@ -120,7 +121,7 @@ class EditCatalogItem extends Page implements HasForms
                     return;
                 }
 
-                $data = $this->itemBaseForm->getState();
+                $data = $this->itemBaseFormSchema()->getState();
                 $this->itemBase->update($data);
 
                 Notification::make()
@@ -157,31 +158,31 @@ class EditCatalogItem extends Page implements HasForms
             return collect();
         }
 
-        $userIds = Item::query()
+        $ownerCounts = Item::query()
             ->where('item_id', $this->itemBase->id)
             ->whereNotNull('user_id')
             ->where('user_id', '>', 0)
             ->groupBy('user_id')
-            ->selectRaw('user_id, COUNT(*) as total')
-            ->orderByDesc('total')
+            ->selectRaw('user_id, COUNT(*) as aggregate')
+            ->orderByDesc('aggregate')
             ->limit(200)
-            ->get();
+            ->pluck('aggregate', 'user_id');
 
-        if ($userIds->isEmpty()) {
+        if ($ownerCounts->isEmpty()) {
             return collect();
         }
 
         $users = User::query()
-            ->whereIn('id', $userIds->pluck('user_id'))
+            ->whereIn('id', $ownerCounts->keys())
             ->get(['id', 'username', 'look', 'rank'])
             ->keyBy('id');
 
-        return $userIds
-            ->map(fn ($row) => [
-                'user' => $users->get($row->user_id),
-                'count' => (int) $row->total,
+        return $ownerCounts
+            ->map(fn ($count, $userId) => [
+                'user' => $users->get((int) $userId),
+                'count' => (int) $count,
             ])
-            ->filter(fn ($r) => $r['user'])
+            ->filter(fn (array $row): bool => $row['user'] !== null)
             ->values();
     }
 
@@ -192,5 +193,17 @@ class EditCatalogItem extends Page implements HasForms
         }
 
         return app(FurniIconService::class)->furniIcon($this->itemBase->item_name);
+    }
+
+    private function catalogFormSchema(): Schema
+    {
+        return $this->getSchema('catalogForm')
+            ?? throw new LogicException('The catalog item form schema is not registered.');
+    }
+
+    private function itemBaseFormSchema(): Schema
+    {
+        return $this->getSchema('itemBaseForm')
+            ?? throw new LogicException('The item base form schema is not registered.');
     }
 }

--- a/app/Filament/Resources/Hotel/CatalogEditors/Pages/ManageCatalogEditor.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Pages/ManageCatalogEditor.php
@@ -75,7 +75,7 @@ class ManageCatalogEditor extends Page implements HasTable
 
     private function findCachedPage(int $id): ?CatalogPage
     {
-        foreach ($this->pagesByParent as $children) {
+        foreach ($this->getPagesByParentProperty() as $children) {
             foreach ($children as $page) {
                 if ($page->id === $id) {
                     return $page;
@@ -88,7 +88,7 @@ class ManageCatalogEditor extends Page implements HasTable
 
     public function getBreadcrumbProperty(): array
     {
-        return $this->tree()->breadcrumb($this->selectedPage);
+        return $this->tree()->breadcrumb($this->getSelectedPageProperty());
     }
 
     public function selectPage(int $pageId): void
@@ -207,17 +207,23 @@ class ManageCatalogEditor extends Page implements HasTable
         return Action::make('editPage')
             ->label('Edit page')
             ->icon('heroicon-m-pencil-square')
-            ->visible(fn () => (bool) $this->selectedPage)
-            ->modalHeading(fn () => $this->selectedPage ? "Edit: {$this->selectedPage->caption}" : 'Edit page')
+            ->visible(fn () => $this->getSelectedPageProperty() !== null)
+            ->modalHeading(function (): string {
+                $selectedPage = $this->getSelectedPageProperty();
+
+                return $selectedPage ? "Edit: {$selectedPage->caption}" : 'Edit page';
+            })
             ->modalWidth('xl')
             ->form(CatalogPageForm::schema())
-            ->fillForm(fn () => $this->selectedPage?->only(['caption', 'caption_save', 'order_num', 'icon_image']) ?? [])
+            ->fillForm(fn () => $this->getSelectedPageProperty()?->only(['caption', 'caption_save', 'order_num', 'icon_image']) ?? [])
             ->action(function (array $data): void {
-                if (! $this->selectedPage) {
+                $selectedPage = $this->getSelectedPageProperty();
+
+                if (! $selectedPage) {
                     return;
                 }
 
-                $this->selectedPage->update([
+                $selectedPage->update([
                     'caption' => $data['caption'],
                     'caption_save' => CatalogPageForm::sanitizeTag($data['caption_save'] ?? ''),
                     'order_num' => (int) ($data['order_num'] ?? 1),
@@ -235,7 +241,7 @@ class ManageCatalogEditor extends Page implements HasTable
             ->icon('heroicon-m-arrow-path')
             ->color('gray')
             ->tooltip('Re-spaces items at 10, 20, 30… while preserving their order. Useful after bulk changes.')
-            ->visible(fn () => $this->selectedPage && $this->selectedPage->parent_id !== -1)
+            ->visible(fn () => ($selectedPage = $this->getSelectedPageProperty()) !== null && $selectedPage->parent_id !== -1)
             ->action(function (): void {
                 $count = $this->reorderService()->resetItemSpacing((int) $this->selectedPageId);
 
@@ -257,7 +263,7 @@ class ManageCatalogEditor extends Page implements HasTable
             ->requiresConfirmation()
             ->modalHeading('Sort items A→Z')
             ->modalDescription('This rewrites order_number for every item on the page. Continue?')
-            ->visible(fn () => $this->selectedPage && $this->selectedPage->parent_id !== -1)
+            ->visible(fn () => ($selectedPage = $this->getSelectedPageProperty()) !== null && $selectedPage->parent_id !== -1)
             ->action(function (): void {
                 $count = $this->reorderService()->sortItemsAlphabetically((int) $this->selectedPageId);
 

--- a/app/Filament/Resources/Hotel/CommandLogs/CommandLogResource.php
+++ b/app/Filament/Resources/Hotel/CommandLogs/CommandLogResource.php
@@ -57,7 +57,8 @@ class CommandLogResource extends Resource
                     ->badge()
                     ->color(fn (string $state): string => match ($state) {
                         'yes' => 'primary',
-                        'no' => 'warning'
+                        'no' => 'warning',
+                        default => 'gray',
                     })
                     ->label(__('filament::resources.columns.success'))
                     ->formatStateUsing(fn (string $state): string => __("filament::resources.options.{$state}")),

--- a/app/Filament/Resources/Shop/WebsiteShopCategories/WebsiteShopCategoryResource.php
+++ b/app/Filament/Resources/Shop/WebsiteShopCategories/WebsiteShopCategoryResource.php
@@ -15,6 +15,7 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 
 class WebsiteShopCategoryResource extends Resource
 {
@@ -105,7 +106,7 @@ class WebsiteShopCategoryResource extends Resource
                 Actions\BulkActionGroup::make([
                     Actions\DeleteBulkAction::make()
                         ->before(function (Actions\DeleteBulkAction $action, Collection $records): void {
-                            if ($records->contains(fn (WebsiteShopCategory $record): bool => $record->packages()->exists())) {
+                            if ($records->contains(fn (Model $record): bool => $record instanceof WebsiteShopCategory && $record->packages()->exists())) {
                                 self::notifyHasPackages();
 
                                 $action->cancel();
@@ -142,6 +143,8 @@ class WebsiteShopCategoryResource extends Resource
 
     public static function getNavigationBadge(): ?string
     {
-        return static::getModel()::where('is_active', true)->count() ?: null;
+        $activeCategories = static::getModel()::where('is_active', true)->count();
+
+        return $activeCategories > 0 ? (string) $activeCategories : null;
     }
 }

--- a/app/Filament/Resources/User/Bans/BanResource.php
+++ b/app/Filament/Resources/User/Bans/BanResource.php
@@ -114,12 +114,14 @@ class BanResource extends Resource
                         'ip' => __('filament::resources.common.IP'),
                         'machine' => __('filament::resources.common.Machine'),
                         'super' => __('filament::resources.common.Super'),
+                        default => $state,
                     })
                     ->color(fn (string $state): string => match ($state) {
                         'account' => 'primary',
                         'ip' => 'success',
                         'machine' => 'primary',
                         'super' => 'danger',
+                        default => 'gray',
                     }),
 
                 TextColumn::make('timestamp')
@@ -128,7 +130,7 @@ class BanResource extends Resource
 
                 TextColumn::make('ban_expire')
                     ->label(__('filament::resources.columns.expires_at'))
-                    ->formatStateUsing(fn (string $state): string => $state == 0 ? __('filament::resources.common.Never') : date('Y-m-d H:i', $state)),
+                    ->formatStateUsing(fn (string $state): string => $state === '0' ? __('filament::resources.common.Never') : date('Y-m-d H:i', (int) $state)),
             ])
             ->filters([
                 //

--- a/app/Filament/Resources/User/Users/Pages/EditUser.php
+++ b/app/Filament/Resources/User/Users/Pages/EditUser.php
@@ -9,14 +9,15 @@ use App\Emulator\Data\Feature;
 use App\Emulator\Emulator;
 use App\Enums\CurrencyTypes;
 use App\Filament\Resources\User\Users\UserResource;
+use App\Models\User;
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Support\Exceptions\Halt;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
+use LogicException;
 
 class EditUser extends EditRecord
 {
@@ -37,20 +38,14 @@ class EditUser extends EditRecord
         );
     }
 
-    public static function getEloquentQuery(): Builder
-    {
-        return Emulator::supports(Feature::EmulatorUserSettings)
-            ? static::getModel()::query()->with(['settings'])
-            : static::getModel()::query();
-    }
-
     /**
      * @throws Halt
      */
     protected function beforeSave(): void
     {
-        $user = $this->getRecord();
-        $data = $this->form->getState();
+        $user = $this->userRecord($this->getRecord());
+        $data = $this->getSchema('form')?->getState()
+            ?? throw new LogicException('The user edit form schema is not registered.');
 
         if ($data['rank'] > auth()->user()->rank) {
             Notification::make()
@@ -75,30 +70,31 @@ class EditUser extends EditRecord
 
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
+        $user = $this->userRecord($record);
         $rcon = app(Rcon::class);
 
-        return DB::transaction(function () use ($record, $data, $rcon): Model {
-            if (! $record->online) {
-                $this->treatChangedCurrenciesWithoutRcon($record, $data);
+        return DB::transaction(function () use ($user, $data, $rcon): Model {
+            if (! $user->online) {
+                $this->treatChangedCurrenciesWithoutRcon($user, $data);
 
-                return parent::handleRecordUpdate($record, $data);
+                return parent::handleRecordUpdate($user, $data);
             }
 
-            if ($data['credits'] != $record->credits) {
-                app(SendCurrency::class)->execute($record, CurrencyTypes::Credits, -$record->credits + $data['credits']);
+            if ($data['credits'] != $user->credits) {
+                app(SendCurrency::class)->execute($user, CurrencyTypes::Credits, -$user->credits + $data['credits']);
             }
 
-            $this->checkUsernameChangedPermission($record, $data, $rcon);
-            $this->treatChangedCurrencies($record, $data);
-            $this->treatChangedUserRank($record, $data, $rcon);
-            $this->treatChangedUserMotto($record, $data, $rcon);
+            $this->checkUsernameChangedPermission($user, $data, $rcon);
+            $this->treatChangedCurrencies($user, $data);
+            $this->treatChangedUserRank($user, $data, $rcon);
+            $this->treatChangedUserMotto($user, $data, $rcon);
 
             // The emulator persists these fields when the deferred RCON commands run.
-            return parent::handleRecordUpdate($record, Arr::except($data, ['credits', 'rank', 'motto']));
+            return parent::handleRecordUpdate($user, Arr::except($data, ['credits', 'rank', 'motto']));
         });
     }
 
-    private function treatChangedCurrenciesWithoutRcon(Model $user, array $data): void
+    private function treatChangedCurrenciesWithoutRcon(User $user, array $data): void
     {
         $currencies = app(CurrencyRepository::class);
 
@@ -122,7 +118,7 @@ class EditUser extends EditRecord
      *
      * @return list<array{CurrencyTypes, int, int}>
      */
-    private function changedCurrencies(Model $user, array $data): array
+    private function changedCurrencies(User $user, array $data): array
     {
         $currencies = app(CurrencyRepository::class);
         $changes = [];
@@ -143,13 +139,13 @@ class EditUser extends EditRecord
         return $changes;
     }
 
-    private function checkUsernameChangedPermission(Model $user, array $data, Rcon $rcon): void
+    private function checkUsernameChangedPermission(User $user, array $data, Rcon $rcon): void
     {
         if (! Emulator::supports(Feature::NameChangePermission)) {
             return;
         }
 
-        if ($data['allow_change_username'] == $user->settings->can_change_name) {
+        if ($user->settings === null || $data['allow_change_username'] == $user->settings->can_change_name) {
             return;
         }
 
@@ -167,7 +163,7 @@ class EditUser extends EditRecord
         $this->updateNameChangePermission($user, $data);
     }
 
-    private function updateNameChangePermission(Model $user, array $data): void
+    private function updateNameChangePermission(User $user, array $data): void
     {
         if (! Emulator::supports(Feature::NameChangePermission) || $user->settings === null) {
             return;
@@ -176,14 +172,14 @@ class EditUser extends EditRecord
         $user->settings->update(['can_change_name' => ($data['allow_change_username'] ?? false) ? '1' : '0']);
     }
 
-    private function treatChangedCurrencies(Model $user, array $data): void
+    private function treatChangedCurrencies(User $user, array $data): void
     {
         foreach ($this->changedCurrencies($user, $data) as [$type, $current, $updated]) {
             app(SendCurrency::class)->execute($user, $type, $updated - $current);
         }
     }
 
-    private function treatChangedUserRank(Model $user, array $data, Rcon $rcon): void
+    private function treatChangedUserRank(User $user, array $data, Rcon $rcon): void
     {
         if ($data['rank'] == $user->rank) {
             return;
@@ -213,7 +209,7 @@ class EditUser extends EditRecord
         $rcon->setRank($user, $data['rank']);
     }
 
-    private function treatChangedUserMotto(Model $user, array $data, Rcon $rcon): void
+    private function treatChangedUserMotto(User $user, array $data, Rcon $rcon): void
     {
         if ($data['motto'] == $user->motto) {
             return;
@@ -237,5 +233,14 @@ class EditUser extends EditRecord
 
         $rcon->setMotto($user, $data['motto']);
         $rcon->alertUser($user, __('Your motto has been changed by a staff member.'));
+    }
+
+    private function userRecord(Model $record): User
+    {
+        if (! $record instanceof User) {
+            throw new LogicException('The user editor received an unsupported model.');
+        }
+
+        return $record;
     }
 }

--- a/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
+++ b/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
@@ -20,6 +20,8 @@ class BadgesRelationManager extends RelationManager
 {
     use TranslatableResource;
 
+    protected static string|\UnitEnum|null $navigationGroup = null;
+
     protected static string $relationship = 'badges';
 
     protected static ?string $recordTitleAttribute = 'badge_code';

--- a/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
+++ b/app/Filament/Resources/User/Users/RelationManagers/BadgesRelationManager.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\User\Users\RelationManagers;
 use App\Contracts\Rcon;
 use App\Filament\Tables\Columns\HabboBadgeColumn;
 use App\Filament\Traits\TranslatableResource;
+use App\Models\User;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -15,6 +16,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use LogicException;
 
 class BadgesRelationManager extends RelationManager
 {
@@ -70,7 +72,7 @@ class BadgesRelationManager extends RelationManager
             ->headerActions([
                 CreateAction::make()
                     ->before(function (CreateAction $action, RelationManager $livewire): void {
-                        $user = $livewire->getOwnerRecord();
+                        $user = self::owner($livewire);
 
                         if (! $user->online) {
                             return;
@@ -111,7 +113,7 @@ class BadgesRelationManager extends RelationManager
 
     public static function onDeleteBadgeAction(DeleteAction|DeleteBulkAction $action, RelationManager $livewire): void
     {
-        $user = $livewire->getOwnerRecord();
+        $user = self::owner($livewire);
 
         if (! $user->online) {
             return;
@@ -127,5 +129,16 @@ class BadgesRelationManager extends RelationManager
             ->send();
 
         $action->cancel();
+    }
+
+    private static function owner(RelationManager $livewire): User
+    {
+        $record = $livewire->getOwnerRecord();
+
+        if (! $record instanceof User) {
+            throw new LogicException('The badge manager received an unsupported owner model.');
+        }
+
+        return $record;
     }
 }

--- a/app/Filament/Resources/User/Users/RelationManagers/SettingsRelationManager.php
+++ b/app/Filament/Resources/User/Users/RelationManagers/SettingsRelationManager.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\User\Users\RelationManagers;
 
 use App\Filament\Traits\TranslatableResource;
+use App\Models\User;
 use Carbon\CarbonInterval;
 use Filament\Actions\Action;
 use Filament\Actions\EditAction;
@@ -15,6 +16,7 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use LogicException;
 
 class SettingsRelationManager extends RelationManager
 {
@@ -179,8 +181,19 @@ class SettingsRelationManager extends RelationManager
             ])
             ->recordActions([
                 EditAction::make()
-                    ->disabled(fn (RelationManager $livewire) => $livewire->getOwnerRecord()->online),
+                    ->disabled(fn (RelationManager $livewire): bool => self::owner($livewire)->online),
             ])
             ->toolbarActions([]);
+    }
+
+    private static function owner(RelationManager $livewire): User
+    {
+        $record = $livewire->getOwnerRecord();
+
+        if (! $record instanceof User) {
+            throw new LogicException('The settings manager received an unsupported owner model.');
+        }
+
+        return $record;
     }
 }

--- a/app/Filament/Resources/User/Users/RelationManagers/SettingsRelationManager.php
+++ b/app/Filament/Resources/User/Users/RelationManagers/SettingsRelationManager.php
@@ -20,6 +20,8 @@ class SettingsRelationManager extends RelationManager
 {
     use TranslatableResource;
 
+    protected static string|\UnitEnum|null $navigationGroup = null;
+
     protected static string $relationship = 'settings';
 
     protected static string $translateIdentifier = 'settings';

--- a/app/Filament/Resources/User/Users/UserResource.php
+++ b/app/Filament/Resources/User/Users/UserResource.php
@@ -32,7 +32,6 @@ use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Hash;
 
 class UserResource extends Resource
@@ -81,21 +80,21 @@ class UserResource extends Resource
                                 DateTimePicker::make('account_created')
                                     ->native(false)
                                     ->displayFormat('Y-m-d H:i:s')
-                                    ->dehydrateStateUsing(fn (Model $record) => $record->account_created)
+                                    ->dehydrateStateUsing(fn (User $record) => $record->account_created)
                                     ->disabled()
                                     ->label(__('filament::resources.inputs.created_at')),
 
                                 DateTimePicker::make('last_login')
                                     ->native(false)
                                     ->displayFormat('Y-m-d H:i:s')
-                                    ->dehydrateStateUsing(fn (Model $record) => $record->last_login)
+                                    ->dehydrateStateUsing(fn (User $record) => $record->last_login)
                                     ->disabled()
                                     ->label(__('filament::resources.inputs.last_login')),
 
                                 DateTimePicker::make('last_online')
                                     ->native(false)
                                     ->displayFormat('Y-m-d H:i:s')
-                                    ->dehydrateStateUsing(fn (Model $record) => $record->last_online)
+                                    ->dehydrateStateUsing(fn (User $record) => $record->last_online)
                                     ->disabled()
                                     ->label(__('filament::resources.inputs.last_online')),
 
@@ -206,7 +205,13 @@ class UserResource extends Resource
 
     public static function getEloquentQuery(): Builder
     {
-        return static::getModel()::query();
+        $query = parent::getEloquentQuery();
+
+        if (Emulator::supports(Feature::EmulatorUserSettings)) {
+            $query->with('settings');
+        }
+
+        return $query;
     }
 
     public static function table(Table $table): Table
@@ -241,7 +246,7 @@ class UserResource extends Resource
 
                 IconColumn::make('online')
                     ->label(__('filament::resources.columns.online'))
-                    ->icon(fn (Model $record) => $record->online ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
+                    ->icon(fn (User $record) => $record->online ? 'heroicon-o-check-circle' : 'heroicon-o-x-circle')
                     ->colors([
                         'danger' => false,
                         'success' => true,
@@ -276,7 +281,7 @@ class UserResource extends Resource
         ]));
     }
 
-    public static function fillWithOutsideData(Model $record, array $formData): array
+    public static function fillWithOutsideData(User $record, array $formData): array
     {
         $formData['currency_0'] = $record->currency('duckets');
         $formData['currency_5'] = $record->currency('diamonds');

--- a/app/Filament/Tables/Columns/UserAvatarColumn.php
+++ b/app/Filament/Tables/Columns/UserAvatarColumn.php
@@ -21,9 +21,7 @@ class UserAvatarColumn extends Column
             return '';
         }
 
-        $figure = ! $this->figurePointer
-            ? $record->look
-            : data_get($record, $this->figurePointer);
+        $figure = (string) data_get($record, $this->figurePointer ?? 'look', '');
 
         return "{$figureImagerUrl}{$figure}{$this->avatarOptions}";
     }

--- a/app/Filament/Widgets/TopDashboardOverview.php
+++ b/app/Filament/Widgets/TopDashboardOverview.php
@@ -19,31 +19,31 @@ class TopDashboardOverview extends BaseWidget
     protected function getStats(): array
     {
         return [
-            Stat::make(__('filament::resources.stats.users_count.title'), Number::format(User::count(), '0', '1', app()->getLocale()))
+            Stat::make(__('filament::resources.stats.users_count.title'), Number::format(User::count(), 0, 1, app()->getLocale()))
                 ->description(__('filament::resources.stats.users_count.description'))
                 ->chart([20, 20])
                 ->descriptionIcon('heroicon-m-user-group', IconPosition::Before)
                 ->color('success'),
 
-            Stat::make(__('filament::resources.stats.furniture_count.title'), Number::format(ItemDefinition::count(), '0', '1', app()->getLocale()))
+            Stat::make(__('filament::resources.stats.furniture_count.title'), Number::format(ItemDefinition::count(), 0, 1, app()->getLocale()))
                 ->description(__('filament::resources.stats.furniture_count.description'))
                 ->descriptionIcon('heroicon-m-cube', IconPosition::Before)
                 ->chart([20, 20])
                 ->color('success'),
 
-            Stat::make(__('filament::resources.stats.rooms_count.title'), Number::format(Room::count(), '0', '1', app()->getLocale()))
+            Stat::make(__('filament::resources.stats.rooms_count.title'), Number::format(Room::count(), 0, 1, app()->getLocale()))
                 ->description(__('filament::resources.stats.rooms_count.description'))
                 ->descriptionIcon('heroicon-m-building-storefront', IconPosition::Before)
                 ->chart([20, 20])
                 ->color('success'),
 
-            Stat::make(__('filament::resources.stats.photos_count.title'), Number::format(CameraWeb::count(), '0', '1', app()->getLocale()))
+            Stat::make(__('filament::resources.stats.photos_count.title'), Number::format(CameraWeb::count(), 0, 1, app()->getLocale()))
                 ->description(__('filament::resources.stats.photos_count.description'))
                 ->descriptionIcon('heroicon-m-camera', IconPosition::Before)
                 ->chart([20, 20])
                 ->color('success'),
 
-            Stat::make(__('filament::resources.stats.badge_count.title'), Number::format(WebsiteBadge::count(), '0', '1', app()->getLocale()))
+            Stat::make(__('filament::resources.stats.badge_count.title'), Number::format(WebsiteBadge::count(), 0, 1, app()->getLocale()))
                 ->description(__('filament::resources.stats.badge_count.description'))
                 ->descriptionIcon('heroicon-m-gif', IconPosition::Before)
                 ->chart([20, 20])

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,7 +31,3 @@ parameters:
         # Nullsafe is intentional - these relations CAN be null at runtime despite PHPDoc
         - identifier: nullsafe.neverNull
           path: app/Models/User.php
-
-    excludePaths:
-        - app/Console/Commands/AtomSetupCommand.php
-        - app/Filament/


### PR DESCRIPTION
## Summary
- remove the broad PHPStan exclusions for Filament and the setup command
- resolve all 102 previously hidden level-5 findings without baselines or inline suppressions
- replace deprecated Filament form access and generic model callbacks with current typed APIs
- fix real admin defects found during analysis, including the permission description field, nullable user settings, cached-config storage lookup, and incomplete display matches
- modernize catalog editor schema access and typed aggregate queries

## Dependencies
- stacked on #117
- transitively includes #111

## Verification
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pint --test app/Filament`
- `composer dump-autoload --strict-psr --no-scripts`
