### PR TITLE
refactor: type application service contracts

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -129,6 +129,11 @@ class CreateNewUser implements CreatesNewUsers
         ]);
     }
 
+    /**
+     * @param  array<string, mixed>  $inputs
+     *
+     * @return array<string, mixed>
+     */
     private function validate(array $inputs): array
     {
         $rules = [

--- a/app/Actions/Fortify/RedirectIfTwoFactorAuthenticatable.php
+++ b/app/Actions/Fortify/RedirectIfTwoFactorAuthenticatable.php
@@ -162,7 +162,7 @@ class RedirectIfTwoFactorAuthenticatable
             : redirect()->route('two-factor.login');
     }
 
-    private function convertUserPassword(User $user, string $password)
+    private function convertUserPassword(User $user, string $password): void
     {
         if ($user->password == md5($password)) {
             $user->update([
@@ -171,6 +171,7 @@ class RedirectIfTwoFactorAuthenticatable
         }
     }
 
+    /** @return array<string, mixed> */
     private function validate(Request $request): array
     {
         $rules = [];

--- a/app/Actions/Fortify/ResetUserPassword.php
+++ b/app/Actions/Fortify/ResetUserPassword.php
@@ -15,6 +15,7 @@ class ResetUserPassword implements ResetsUserPasswords
      * Validate and reset the user's forgotten password.
      *
      * @param  mixed  $user
+     * @param  array<string, mixed>  $input
      */
     public function reset($user, array $input): void
     {

--- a/app/Actions/Fortify/Rules/PasswordValidationRules.php
+++ b/app/Actions/Fortify/Rules/PasswordValidationRules.php
@@ -8,6 +8,8 @@ trait PasswordValidationRules
 {
     /**
      * Get the validation rules used to validate passwords.
+     *
+     * @return array<int, mixed>
      */
     protected function passwordRules(): array
     {

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -15,6 +15,7 @@ class UpdateUserPassword implements UpdatesUserPasswords
      * Validate and update the user's password.
      *
      * @param  mixed  $user
+     * @param  array<string, mixed>  $input
      */
     public function update($user, array $input): void
     {

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -13,6 +13,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
      * Validate and update the given user's profile information.
      *
      * @param  mixed  $user
+     * @param  array<string, mixed>  $input
      */
     public function update($user, array $input): void
     {
@@ -43,6 +44,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
      * Update the given verified user's profile information.
      *
      * @param  mixed  $user
+     * @param  array<string, mixed>  $input
      */
     protected function updateVerifiedUser($user, array $input): void
     {

--- a/app/Console/Commands/AtomSetupCommand.php
+++ b/app/Console/Commands/AtomSetupCommand.php
@@ -12,7 +12,7 @@ class AtomSetupCommand extends Command
 
     protected $description = 'Takes you through a basic setup, allowing you to define general settings';
 
-    private function progressInfo(int $step)
+    private function progressInfo(int $step): void
     {
         $this->info(sprintf('Step %s/13', $step));
         $this->newLine();

--- a/app/Console/Commands/BuildTheme.php
+++ b/app/Console/Commands/BuildTheme.php
@@ -12,7 +12,7 @@ class BuildTheme extends Command
 
     protected $description = 'Build a selected theme assets';
 
-    public function handle()
+    public function handle(): int
     {
         $themes = $this->getAvailableThemes();
 
@@ -35,6 +35,7 @@ class BuildTheme extends Command
         return Command::SUCCESS;
     }
 
+    /** @return Collection<int, string> */
     private function getAvailableThemes(): Collection
     {
         $themesPath = resource_path('themes');

--- a/app/Console/Commands/ImportAdsData.php
+++ b/app/Console/Commands/ImportAdsData.php
@@ -55,6 +55,7 @@ class ImportAdsData extends Command
         return true;
     }
 
+    /** @return list<string> */
     private function getImageFiles(string $adsPath): array
     {
         return array_filter(scandir($adsPath), function ($file) use ($adsPath) {
@@ -65,6 +66,7 @@ class ImportAdsData extends Command
         });
     }
 
+    /** @param  list<string>  $files */
     private function processFiles(array $files): void
     {
         // Get existing images to avoid duplicates

--- a/app/Data/SessionLogData.php
+++ b/app/Data/SessionLogData.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Data;
+
+final readonly class SessionLogData
+{
+    /**
+     * @param  array{is_desktop: bool, platform: string|bool, browser: string|bool}  $agent
+     */
+    public function __construct(
+        public array $agent,
+        public ?string $ipAddress,
+        public bool $isCurrentDevice,
+        public string $lastActive,
+    ) {}
+}

--- a/app/Http/Controllers/Api/HotelApiController.php
+++ b/app/Http/Controllers/Api/HotelApiController.php
@@ -15,6 +15,7 @@ class HotelApiController extends Controller
 {
     public function __construct(private readonly UserApiService $userApiService) {}
 
+    /** @param  list<string>  $columns */
     public function fetchUser(string $username, array $columns = ['username', 'motto', 'look']): UserResource
     {
         return new UserResource($this->userApiService->fetchUser($username, $columns));

--- a/app/Http/Controllers/Community/Staff/StaffApplicationsController.php
+++ b/app/Http/Controllers/Community/Staff/StaffApplicationsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Community\Staff;
 use App\Http\Controllers\Controller;
 use App\Models\Community\Staff\WebsiteOpenPosition;
 use App\Models\Community\Staff\WebsiteStaffApplications;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -32,7 +33,7 @@ class StaffApplicationsController extends Controller
         return view('community.staff-apply', compact('position'));
     }
 
-    public function store(Request $request, WebsiteOpenPosition $position)
+    public function store(Request $request, WebsiteOpenPosition $position): RedirectResponse
     {
         abort_unless($position->position_kind === 'rank', 404);
 

--- a/app/Http/Controllers/Community/Staff/WebsiteTeamApplicationsController.php
+++ b/app/Http/Controllers/Community/Staff/WebsiteTeamApplicationsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Community\Staff;
 use App\Http\Controllers\Controller;
 use App\Models\Community\Staff\WebsiteOpenPosition;
 use App\Models\Community\Staff\WebsiteStaffApplications;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -48,7 +49,7 @@ class WebsiteTeamApplicationsController extends Controller
         ]);
     }
 
-    public function store(Request $request, WebsiteOpenPosition $position)
+    public function store(Request $request, WebsiteOpenPosition $position): RedirectResponse
     {
         abort_unless($position->position_kind === 'team', 404);
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -11,6 +11,7 @@ class Controller extends BaseController
 {
     use AuthorizesRequests, ValidatesRequests;
 
+    /** @param  array<string, mixed>  $args */
     public function jsonResponse(array $args, int $status = 200): JsonResponse
     {
         return response()->json([

--- a/app/Http/Controllers/Help/HelpCenterController.php
+++ b/app/Http/Controllers/Help/HelpCenterController.php
@@ -4,10 +4,11 @@ namespace App\Http\Controllers\Help;
 
 use App\Http\Controllers\Controller;
 use App\Models\Help\WebsiteHelpCenterCategory;
+use Illuminate\View\View;
 
 class HelpCenterController extends Controller
 {
-    public function __invoke()
+    public function __invoke(): View
     {
         return view('help-center.index', [
             'categories' => WebsiteHelpCenterCategory::orderBy('position')->get(),

--- a/app/Http/Controllers/Help/TicketReplyController.php
+++ b/app/Http/Controllers/Help/TicketReplyController.php
@@ -6,10 +6,11 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\WebsiteTicketReplyFormRequest;
 use App\Models\Help\WebsiteHelpCenterTicket;
 use App\Models\Help\WebsiteHelpCenterTicketReply;
+use Illuminate\Http\RedirectResponse;
 
 class TicketReplyController extends Controller
 {
-    public function store(WebsiteHelpCenterTicket $ticket, WebsiteTicketReplyFormRequest $request)
+    public function store(WebsiteHelpCenterTicket $ticket, WebsiteTicketReplyFormRequest $request): RedirectResponse
     {
         if (! $ticket->isOpen()) {
             return redirect()->back()->with([
@@ -32,7 +33,7 @@ class TicketReplyController extends Controller
         return redirect()->back()->with('success', __('The reply has been submitted!'));
     }
 
-    public function destroy(WebsiteHelpCenterTicketReply $reply)
+    public function destroy(WebsiteHelpCenterTicketReply $reply): RedirectResponse
     {
         if (! $reply->canDeleteReply()) {
             return redirect()->back()->with([

--- a/app/Http/Controllers/Miscellaneous/InstallationController.php
+++ b/app/Http/Controllers/Miscellaneous/InstallationController.php
@@ -8,18 +8,21 @@ use App\Models\Miscellaneous\WebsiteSetting;
 use App\Rules\ValidateInstallationKeyRule;
 use App\Services\InstallationService;
 use Exception;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 
 class InstallationController extends Controller
 {
-    public function index()
+    public function index(): View
     {
         return view('installation.index');
     }
 
-    public function storeInstallationKey(Request $request)
+    public function storeInstallationKey(Request $request): RedirectResponse
     {
         $request->validate([
             'installation_key' => ['required', 'string', 'max:255', new ValidateInstallationKeyRule],
@@ -33,16 +36,16 @@ class InstallationController extends Controller
         return to_route('installation.show-step', 1);
     }
 
-    public function showStep($currentStep)
+    public function showStep(int $currentStep): View
     {
-        $settings = $this->getSettingsForStep((int) $currentStep);
+        $settings = $this->getSettingsForStep($currentStep);
 
         return view('installation.step-' . $currentStep, [
             'settings' => $settings,
         ]);
     }
 
-    public function saveStepSettings(Request $request)
+    public function saveStepSettings(Request $request): RedirectResponse
     {
         $this->updateSettings($request);
 
@@ -51,14 +54,14 @@ class InstallationController extends Controller
         return to_route('installation.show-step', WebsiteInstallation::first()->step);
     }
 
-    public function previousStep()
+    public function previousStep(): RedirectResponse
     {
         WebsiteInstallation::first()->decrement('step');
 
         return to_route('installation.show-step', WebsiteInstallation::first()->step);
     }
 
-    public function restartInstallation()
+    public function restartInstallation(): RedirectResponse
     {
         WebsiteInstallation::first()->update([
             'step' => 0,
@@ -73,7 +76,7 @@ class InstallationController extends Controller
         return to_route('installation.index');
     }
 
-    public function completeInstallation()
+    public function completeInstallation(): RedirectResponse
     {
         // Clear all caches before marking as complete
         Cache::forget('website_permissions');
@@ -103,7 +106,8 @@ class InstallationController extends Controller
         // Cache will be automatically cleared by WebsiteSetting model events
     }
 
-    private function getSettingsForStep(int $step)
+    /** @return Collection<int, WebsiteSetting> */
+    private function getSettingsForStep(int $step): Collection
     {
         $settingsData = array_chunk(WebsiteSetting::all()->pluck('key')->toArray(), (int) ceil(WebsiteSetting::count() / 4));
 

--- a/app/Http/Controllers/Miscellaneous/LogoGeneratorController.php
+++ b/app/Http/Controllers/Miscellaneous/LogoGeneratorController.php
@@ -6,11 +6,14 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\LogoGeneratorRequest;
 use App\Models\Miscellaneous\WebsiteSetting;
 use App\Services\SettingsService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Str;
+use Illuminate\View\View;
 
 class LogoGeneratorController extends Controller
 {
-    public function index()
+    public function index(): RedirectResponse|View
     {
         if (! hasPermission('generate_logo')) {
             return to_route('me.show')->with([
@@ -21,7 +24,7 @@ class LogoGeneratorController extends Controller
         return view('logo-generator');
     }
 
-    public function store(LogoGeneratorRequest $request)
+    public function store(LogoGeneratorRequest $request): JsonResponse
     {
         $file = $request->file('logo');
         $directory = 'assets/images/generated-logos';

--- a/app/Http/Controllers/User/UserReferralController.php
+++ b/app/Http/Controllers/User/UserReferralController.php
@@ -4,10 +4,11 @@ namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use Illuminate\View\View;
 
 class UserReferralController extends Controller
 {
-    public function __invoke(string $referralCode)
+    public function __invoke(string $referralCode): View
     {
         User::where('referral_code', '=', $referralCode)->firstOrFail();
 

--- a/app/Http/Middleware/InstallationMiddleware.php
+++ b/app/Http/Middleware/InstallationMiddleware.php
@@ -7,16 +7,18 @@ use App\Models\Miscellaneous\WebsiteInstallation;
 use App\Services\InstallationService;
 use Closure;
 use Exception;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
 
 class InstallationMiddleware
 {
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): Response
     {
         if (app(InstallationService::class)->isComplete()) {
             if ($request->is('installation*')) {
@@ -39,7 +41,7 @@ class InstallationMiddleware
         return $next($request);
     }
 
-    private function ensureInstallationTableExists()
+    private function ensureInstallationTableExists(): void
     {
         if (! Schema::hasTable('website_installation')) {
             Artisan::call('migrate', ['--path' => 'database/migrations/' . findMigration('website_installation')]);
@@ -54,7 +56,7 @@ class InstallationMiddleware
         }
     }
 
-    private function getInstallation()
+    private function getInstallation(): WebsiteInstallation
     {
         try {
             $cacheKey = 'installation_record';
@@ -91,7 +93,7 @@ class InstallationMiddleware
         }
     }
 
-    private function handleInstallationSteps(Request $request, WebsiteInstallation $installation)
+    private function handleInstallationSteps(Request $request, WebsiteInstallation $installation): bool
     {
         if ($installation->completed) {
             return true;
@@ -120,54 +122,54 @@ class InstallationMiddleware
         return true;
     }
 
-    private function isWelcomeStep(Request $request, WebsiteInstallation $installation)
+    private function isWelcomeStep(Request $request, WebsiteInstallation $installation): bool
     {
         return $installation->step === 0 && $request->getRequestUri() === '/installation';
     }
 
-    private function isRedirectToWelcome(Request $request, WebsiteInstallation $installation)
+    private function isRedirectToWelcome(Request $request, WebsiteInstallation $installation): bool
     {
         return $installation->step === 0 && $request->getRequestUri() !== '/installation' && $request->method() !== 'POST';
     }
 
-    private function isInvalidAccess(Request $request, WebsiteInstallation $installation)
+    private function isInvalidAccess(Request $request, WebsiteInstallation $installation): bool
     {
         return $installation->step > 0 && $request->ip() !== $installation->user_ip;
     }
 
-    private function isInvalidStep(Request $request)
+    private function isInvalidStep(Request $request): bool
     {
         return ! $this->isValidStep($request) && $this->isNonPostRequest($request);
     }
 
-    private function isMismatchedStep(Request $request, WebsiteInstallation $installation)
+    private function isMismatchedStep(Request $request, WebsiteInstallation $installation): bool
     {
         return $this->getCurrentStep($request) !== $installation->step && $this->isNonPostRequest($request);
     }
 
-    private function isValidStep(Request $request)
+    private function isValidStep(Request $request): bool
     {
         $step = $this->getCurrentStep($request);
 
         return filter_var($step, FILTER_VALIDATE_INT) !== false;
     }
 
-    private function isNonPostRequest(Request $request)
+    private function isNonPostRequest(Request $request): bool
     {
         return $request->method() !== 'POST' || $request->is('restart-installation');
     }
 
-    private function getCurrentStep(Request $request)
+    private function getCurrentStep(Request $request): int
     {
         return (int) Str::after($request->path(), 'step/');
     }
 
-    private function redirectToStep(int $step)
+    private function redirectToStep(int $step): RedirectResponse
     {
         return to_route('installation.show-step', $step);
     }
 
-    protected function redirectIfNotCompleted(WebsiteInstallation $installation)
+    protected function redirectIfNotCompleted(WebsiteInstallation $installation): RedirectResponse
     {
 
         if ($installation->step === 0) {

--- a/app/Http/Requests/AccountSettingsFormRequest.php
+++ b/app/Http/Requests/AccountSettingsFormRequest.php
@@ -11,6 +11,7 @@ use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class AccountSettingsFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         $rules = [

--- a/app/Http/Requests/AccountTopupFormRequest.php
+++ b/app/Http/Requests/AccountTopupFormRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class AccountTopupFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/ArticleCommentFormRequest.php
+++ b/app/Http/Requests/ArticleCommentFormRequest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class ArticleCommentFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/LogoGeneratorRequest.php
+++ b/app/Http/Requests/LogoGeneratorRequest.php
@@ -11,6 +11,7 @@ class LogoGeneratorRequest extends FormRequest
         return hasPermission('generate_logo');
     }
 
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/PasswordSettingsFormRequest.php
+++ b/app/Http/Requests/PasswordSettingsFormRequest.php
@@ -12,6 +12,7 @@ class PasswordSettingsFormRequest extends FormRequest
 {
     use PasswordValidationRules;
 
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/RareSearchFormRequest.php
+++ b/app/Http/Requests/RareSearchFormRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class RareSearchFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/RegisterFormRequest.php
+++ b/app/Http/Requests/RegisterFormRequest.php
@@ -11,6 +11,7 @@ class RegisterFormRequest extends FormRequest
 {
     protected $errorBag = 'register';
 
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/ShopVoucherFormRequest.php
+++ b/app/Http/Requests/ShopVoucherFormRequest.php
@@ -8,6 +8,7 @@ use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class ShopVoucherFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/StaffApplicationFormRequest.php
+++ b/app/Http/Requests/StaffApplicationFormRequest.php
@@ -8,6 +8,7 @@ use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class StaffApplicationFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/WebsiteTicketFormRequest.php
+++ b/app/Http/Requests/WebsiteTicketFormRequest.php
@@ -7,6 +7,7 @@ use Illuminate\Validation\Rule;
 
 class WebsiteTicketFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Requests/WebsiteTicketReplyFormRequest.php
+++ b/app/Http/Requests/WebsiteTicketReplyFormRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class WebsiteTicketReplyFormRequest extends FormRequest
 {
+    /** @return array<string, mixed> */
     public function rules(): array
     {
         return [

--- a/app/Http/Resources/OnlineUserCountResource.php
+++ b/app/Http/Resources/OnlineUserCountResource.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class OnlineUserCountResource extends JsonResource
 {
+    /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
         return [

--- a/app/Http/Resources/OnlineUsersResource.php
+++ b/app/Http/Resources/OnlineUsersResource.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class OnlineUsersResource extends JsonResource
 {
+    /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
         return [

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class UserResource extends JsonResource
 {
+    /** @return array<string, mixed> */
     public function toArray(Request $request): array
     {
         return [

--- a/app/Livewire/ArticleReactions.php
+++ b/app/Livewire/ArticleReactions.php
@@ -98,7 +98,7 @@ class ArticleReactions extends Component
             : collect();
 
         $usedReactionNames = $articleReactions->pluck('name')->values();
-        $availableReactions = collect(config('habbo.reactions'))
+        $availableReactions = collect((array) config('habbo.reactions', []))
             ->reject(fn ($reaction) => $usedReactionNames->contains($reaction) || $myReactions->contains($reaction))
             ->values();
 

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -81,7 +81,7 @@ class FortifyServiceProvider extends ServiceProvider
         ];
     }
 
-    private function authenticate()
+    private function authenticate(): void
     {
         Fortify::authenticateThrough(function () {
             return array_filter([

--- a/app/Rules/Password.php
+++ b/app/Rules/Password.php
@@ -85,7 +85,7 @@ class Password implements Rule
     /**
      * Set the minimum length of the password.
      */
-    public function length(int $length)
+    public function length(int $length): static
     {
         $this->length = $length;
 

--- a/app/Services/Articles/ArticleService.php
+++ b/app/Services/Articles/ArticleService.php
@@ -8,7 +8,10 @@ use Illuminate\Database\Eloquent\Collection;
 
 class ArticleService
 {
-    public function getArticles(bool $paginate = false, int $perPage = 8): array|Collection|LengthAwarePaginator
+    /**
+     * @return Collection<int, WebsiteArticle>|LengthAwarePaginator<int, WebsiteArticle>
+     */
+    public function getArticles(bool $paginate = false, int $perPage = 8): Collection|LengthAwarePaginator
     {
         $query = WebsiteArticle::with(['user' => function ($query) {
             $query->select('id', 'username', 'look');

--- a/app/Services/Articles/ReactionService.php
+++ b/app/Services/Articles/ReactionService.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 
 class ReactionService
 {
+    /** @return array{success: bool, added?: bool, username?: string} */
     public function toggleReaction(WebsiteArticle $article, User $user, Request $request): array
     {
         $reaction = $request->get('reaction');

--- a/app/Services/Catalog/CatalogReorderService.php
+++ b/app/Services/Catalog/CatalogReorderService.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\DB;
  */
 class CatalogReorderService
 {
+    /** @param  array<int, mixed>  $orderedIds */
     public function reorderPages(int $parentId, array $orderedIds): void
     {
         $clean = $this->cleanIds($orderedIds);
@@ -59,6 +60,7 @@ class CatalogReorderService
         });
     }
 
+    /** @param  array<int, mixed>  $orderedIds */
     public function reorderItems(int $pageId, array $orderedIds): void
     {
         $clean = $this->cleanIds($orderedIds);
@@ -121,7 +123,11 @@ class CatalogReorderService
         return $items->count();
     }
 
-    /** Appends to the destination page's tail. */
+    /**
+     * Appends to the destination page's tail.
+     *
+     * @param  array<int, mixed>  $itemIds
+     */
     public function moveItemsToPage(int $targetPageId, array $itemIds): int
     {
         $clean = $this->cleanIds($itemIds);
@@ -142,7 +148,11 @@ class CatalogReorderService
         return count($clean);
     }
 
-    /** @return array<int, int> */
+    /**
+     * @param  array<int, mixed>  $ids
+     *
+     * @return list<int>
+     */
     private function cleanIds(array $ids): array
     {
         return array_values(array_unique(array_filter(

--- a/app/Services/Community/RareValues/RareValueCategoriesService.php
+++ b/app/Services/Community/RareValues/RareValueCategoriesService.php
@@ -3,17 +3,18 @@
 namespace App\Services\Community\RareValues;
 
 use App\Models\Community\RareValue\WebsiteRareValueCategory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
 class RareValueCategoriesService
 {
+    /** @return Collection<int, WebsiteRareValueCategory> */
     public function fetchAllCategories(): Collection
     {
         return WebsiteRareValueCategory::all();
     }
 
-    public function fetchCategoriesByPriority(): Builder|Collection
+    /** @return Collection<int, WebsiteRareValueCategory> */
+    public function fetchCategoriesByPriority(): Collection
     {
         return WebsiteRareValueCategory::orderBy('priority')->with('furniture')->get();
     }
@@ -23,6 +24,7 @@ class RareValueCategoriesService
         return WebsiteRareValueCategory::orderBy('priority')->whereId($id)->with('furniture')->first();
     }
 
+    /** @return Collection<int, WebsiteRareValueCategory> */
     public function searchCategories(string $searchTerm): Collection
     {
         return WebsiteRareValueCategory::orderBy('priority')->whereHas('furniture', function ($query) use ($searchTerm) {

--- a/app/Services/Community/StaffApplicationService.php
+++ b/app/Services/Community/StaffApplicationService.php
@@ -16,17 +16,18 @@ class StaffApplicationService
         ]);
     }
 
+    /** @return Collection<int, WebsiteOpenPosition> */
     public function fetchOpenPositions(): Collection
     {
         return WebsiteOpenPosition::canApply()->with('permission')->get();
     }
 
-    public function hasUserAppliedForPosition($user, $positionId): bool
+    public function hasUserAppliedForPosition(User $user, int $positionId): bool
     {
         return $user->applications()->where('rank_id', $positionId)->exists();
     }
 
-    public function isPositionOpenForApplication($position): bool
+    public function isPositionOpenForApplication(WebsiteOpenPosition $position): bool
     {
         $currentTime = now();
 

--- a/app/Services/Community/StaffService.php
+++ b/app/Services/Community/StaffService.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Cache;
 
 class StaffService
 {
+    /** @return Collection<int, Permission> */
     public function fetchStaffPositions(): Collection
     {
         $cacheEnabled = setting('enable_caching') === '1';
@@ -42,6 +43,7 @@ class StaffService
         return $employees;
     }
 
+    /** @return list<int> */
     public function fetchEmployeeIds(): array
     {
         $cacheEnabled = setting('enable_caching') === '1';

--- a/app/Services/Community/TeamService.php
+++ b/app/Services/Community/TeamService.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 
 class TeamService
 {
+    /** @return Collection<int, WebsiteTeam> */
     public function fetchTeams(): Collection
     {
         $cacheEnabled = setting('enable_caching') === '1';

--- a/app/Services/Home/HomeService.php
+++ b/app/Services/Home/HomeService.php
@@ -80,6 +80,7 @@ class HomeService
         });
     }
 
+    /** @param  array{backgroundId?: int, items?: list<array<string, mixed>>}  $data */
     public function saveItems(User $user, array $data): void
     {
         if (isset($data['backgroundId'])) {

--- a/app/Services/HousekeepingPermissionsService.php
+++ b/app/Services/HousekeepingPermissionsService.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Collection;
 
 class HousekeepingPermissionsService
 {
+    /** @var Collection<string, int> */
     public Collection $permissions;
 
     public function __construct()

--- a/app/Services/IpLookupService.php
+++ b/app/Services/IpLookupService.php
@@ -10,7 +10,8 @@ class IpLookupService
 
     public function __construct(private string $apiKey) {}
 
-    public function ipLookup(string $ip)
+    /** @return array<string, mixed> */
+    public function ipLookup(string $ip): array
     {
         $response = Http::acceptJson()->get(sprintf('%s/%s?api-key=%s', $this->baseUrl, $ip, $this->apiKey));
 

--- a/app/Services/PermissionsService.php
+++ b/app/Services/PermissionsService.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 
 class PermissionsService
 {
+    /** @var Collection<string, int> */
     public Collection $permissions;
 
     public function __construct()

--- a/app/Services/SettingsService.php
+++ b/app/Services/SettingsService.php
@@ -10,9 +10,11 @@ use Throwable;
 
 class SettingsService
 {
+    /** @var Collection<string, mixed>|null */
     private ?Collection $cachedSettings = null;
 
-    protected function settings()
+    /** @return Collection<string, mixed> */
+    protected function settings(): Collection
     {
         if ($this->cachedSettings !== null) {
             return $this->cachedSettings;
@@ -51,7 +53,8 @@ class SettingsService
         }
     }
 
-    private function fetchSettings()
+    /** @return Collection<string, mixed> */
+    private function fetchSettings(): Collection
     {
         try {
             if (! Schema::hasTable('website_settings')) {

--- a/app/Services/User/SessionService.php
+++ b/app/Services/User/SessionService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\User;
 
+use App\Data\SessionLogData;
+use App\Models\Session;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
@@ -10,6 +12,9 @@ use Jenssegers\Agent\Agent;
 
 class SessionService
 {
+    /**
+     * @return Collection<int, SessionLogData>
+     */
     public function fetchSessionLogs(Request $request): Collection
     {
         return collect(
@@ -17,20 +22,20 @@ class SessionService
         )->map(function ($session) use ($request) {
             $agent = $this->createAgent($session);
 
-            return (object) [
-                'agent' => [
+            return new SessionLogData(
+                agent: [
                     'is_desktop' => $agent->isDesktop(),
                     'platform' => $agent->platform(),
                     'browser' => $agent->browser(),
                 ],
-                'ip_address' => $session->ip_address,
-                'is_current_device' => $session->id === $request->session()->getId(),
-                'last_active' => Carbon::createFromTimestamp($session->last_activity)->diffForHumans(),
-            ];
+                ipAddress: $session->ip_address,
+                isCurrentDevice: $session->id === $request->session()->getId(),
+                lastActive: Carbon::createFromTimestamp($session->last_activity)->diffForHumans(),
+            );
         });
     }
 
-    protected function createAgent($session): Agent
+    protected function createAgent(Session $session): Agent
     {
         return tap(new Agent, function ($agent) use ($session) {
             $agent->setUserAgent($session->user_agent);

--- a/app/Services/User/UserApiService.php
+++ b/app/Services/User/UserApiService.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Cache;
 
 class UserApiService
 {
+    /** @param  list<string>  $columns */
     public function fetchUser(string $username, array $columns): ?User
     {
         return User::select($columns)->where('username', $username)->first();

--- a/resources/themes/atom/views/user/settings/session-logs.blade.php
+++ b/resources/themes/atom/views/user/settings/session-logs.blade.php
@@ -44,17 +44,17 @@
                         @forelse ($logs as $log)
                             <tr>
                                 <td class="whitespace-nowrap px-4 py-2 font-medium text-gray-900 dark:text-gray-300">
-                                    {{ $log->ip_address }}
+                                    {{ $log->ipAddress }}
                                 </td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
-                                    {{ $log->is_current_device ? 'true' : 'false' }}</td>
+                                    {{ $log->isCurrentDevice ? 'true' : 'false' }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">
                                     {{ $log->agent['is_desktop'] ? 'true' : 'false' }}</td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $log->agent['platform'] }}
                                 </td>
                                 <td class="px-4 py-2 text-gray-700 dark:text-gray-300">{{ $log->agent['browser'] }}</td>
                                 <td class="whitespace-nowrap px-4 py-2 text-gray-700 dark:text-gray-300">
-                                    {{ $log->last_active }}</td>
+                                    {{ $log->lastActive }}</td>
                             </tr>
                         @empty
                             <tr>

--- a/resources/themes/dusk/views/user/settings/session-logs.blade.php
+++ b/resources/themes/dusk/views/user/settings/session-logs.blade.php
@@ -44,17 +44,17 @@
                         @forelse ($logs as $log)
                             <tr>
                                 <td class="whitespace-nowrap px-4 py-2 font-medium text-gray-200">
-                                    {{ $log->ip_address }}
+                                    {{ $log->ipAddress }}
                                 </td>
                                 <td class="px-4 py-2 text-gray-200">
-                                    {{ $log->is_current_device ? 'true' : 'false' }}</td>
+                                    {{ $log->isCurrentDevice ? 'true' : 'false' }}</td>
                                 <td class="px-4 py-2 text-gray-200">
                                     {{ $log->agent['is_desktop'] ? 'true' : 'false' }}</td>
                                 <td class="px-4 py-2 text-gray-200">{{ $log->agent['platform'] }}
                                 </td>
                                 <td class="px-4 py-2 text-gray-200">{{ $log->agent['browser'] }}</td>
                                 <td class="whitespace-nowrap px-4 py-2 text-gray-200">
-                                    {{ $log->last_active }}</td>
+                                    {{ $log->lastActive }}</td>
                             </tr>
                         @empty
                             <tr>


### PR DESCRIPTION
## Summary
- resolve all 102 level-6 findings outside models and Filament
- add explicit controller, middleware, request, resource, command, and service contracts
- correct misleading article and rare-value return types
- type catalog reorder inputs and home layout payloads
- replace anonymous session log objects with a readonly data contract

## Dependency
- stacked on #120

## Verification
- application code outside `app/Models` and `app/Filament` is clean at PHPStan level 6
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pint --test` on changed PHP areas
- `npx prettier --check` on changed Blade files
