### PR TITLE
fix: secure remote badge image handling

### DIFF
--- a/app/Filament/Pages/BadgePage.php
+++ b/app/Filament/Pages/BadgePage.php
@@ -4,6 +4,8 @@ namespace App\Filament\Pages;
 
 use App\Filament\Traits\TranslatableResource;
 use App\Services\Parsers\ExternalTextsParser;
+use App\Support\OutboundHttp;
+use App\Support\PublicHttpUrlResolver;
 use Filament\Actions\Action;
 use Filament\Actions\Action as PageAction;
 use Filament\Actions\ActionGroup;
@@ -16,12 +18,13 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
 class BadgePage extends Page
 {
+    private const MAX_BADGE_IMAGE_BYTES = 1_048_576;
+
     use InteractsWithForms, TranslatableResource;
 
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
@@ -60,8 +63,11 @@ class BadgePage extends Page
                         TextInput::make('code')
                             ->label(__('filament::resources.inputs.badge_code'))
                             ->helperText(__('filament::resources.helpers.badge_code_helper'))
+                            ->required()
+                            ->maxLength(64)
+                            ->regex('/\A[A-Z0-9_-]+\z/')
                             ->afterStateUpdated(function (?string $state, Set $set) {
-                                $set('code', strtoupper($state));
+                                $set('code', is_string($state) ? strtoupper($state) : null);
                             })
                             ->suffixAction(fn (): PageAction => PageAction::make('search')->icon('heroicon-o-magnifying-glass')->action(fn () => $this->searchBadgesByCode()),
                             ),
@@ -116,9 +122,9 @@ class BadgePage extends Page
 
     private function searchBadgesByCode(): void
     {
-        $badgeCode = $this->data['code'] ?? null;
+        $badgeCode = $this->badgeCode();
 
-        if (empty($badgeCode)) {
+        if ($badgeCode === null) {
             Notification::make()
                 ->danger()
                 ->title(__('filament::resources.notifications.badge_code_required'))
@@ -126,6 +132,8 @@ class BadgePage extends Page
 
             return;
         }
+
+        $this->data['code'] = $badgeCode;
 
         $badgeData = app(ExternalTextsParser::class)->getBadgeData($badgeCode);
         $this->badgeWasPreviouslyCreated = is_array($badgeData['nitro']) || is_array($badgeData['flash']);
@@ -196,18 +204,28 @@ class BadgePage extends Page
     {
         $nitroEnabled = config('hotel.client.nitro.enabled');
         $flashEnabled = config('hotel.client.flash.enabled');
+        $badgeCode = $this->badgeCode();
 
-        // image and code fields are required when creating a new badge
-        if (! $this->badgeWasPreviouslyCreated && (empty($this->data['image']) || empty($this->data['code']))) {
-            $notificationTitle = empty($this->data['image']) ?
-                __('filament::resources.notifications.badge_image_required') :
-                __('filament::resources.notifications.badge_code_required');
-
+        if ($badgeCode === null) {
             Notification::make()
                 ->icon('heroicon-o-exclamation-triangle')
                 ->iconColor('danger')
                 ->color('danger')
-                ->title($notificationTitle)
+                ->title(__('filament::resources.notifications.badge_code_required'))
+                ->send();
+
+            return;
+        }
+
+        $this->data['code'] = $badgeCode;
+
+        // image and code fields are required when creating a new badge
+        if (! $this->badgeWasPreviouslyCreated && empty($this->data['image'])) {
+            Notification::make()
+                ->icon('heroicon-o-exclamation-triangle')
+                ->iconColor('danger')
+                ->color('danger')
+                ->title(__('filament::resources.notifications.badge_image_required'))
                 ->send();
 
             return;
@@ -227,13 +245,15 @@ class BadgePage extends Page
         }
 
         try {
-            $this->uploadBadgeImage($externalTextsParser);
+            if (! $this->uploadBadgeImage($externalTextsParser, $badgeCode)) {
+                return;
+            }
 
             if (! empty($this->data['nitro']) && $nitroEnabled) {
-                $externalTextsParser->updateNitroBadgeTexts($this->data['code'], ...$this->data['nitro']);
+                $externalTextsParser->updateNitroBadgeTexts($badgeCode, ...$this->data['nitro']);
             }
             if (! empty($this->data['flash']) && $flashEnabled) {
-                $externalTextsParser->updateFlashBadgeTexts($this->data['code'], ...$this->data['flash']);
+                $externalTextsParser->updateFlashBadgeTexts($badgeCode, ...$this->data['flash']);
             }
         } catch (Throwable $exception) {
             Log::channel('badge')->error('[ORION BADGE RESOURCE] - ERROR: ' . $exception->getMessage());
@@ -248,7 +268,7 @@ class BadgePage extends Page
             return;
         }
 
-        $this->data['image'] = $externalTextsParser->getBadgeImageUrl($this->data['code']);
+        $this->data['image'] = $externalTextsParser->getBadgeImageUrl($badgeCode);
         $this->badgeWasPreviouslyCreated = true;
 
         Notification::make()
@@ -259,49 +279,107 @@ class BadgePage extends Page
             ->send();
     }
 
-    protected function uploadBadgeImage(ExternalTextsParser $parser): void
+    protected function uploadBadgeImage(ExternalTextsParser $parser, string $badgeCode): bool
     {
-        if (empty($this->data['image']) || ! filter_var($this->data['image'], FILTER_VALIDATE_URL)) {
-            return;
+        $imageUrl = $this->data['image'] ?? null;
+
+        if (! is_string($imageUrl) || trim($imageUrl) === '') {
+            return true;
         }
 
-        if ($this->data['image'] == $parser->getBadgeImageUrl($this->data['code'])) {
-            return;
+        if ($imageUrl === $parser->getBadgeImageUrl($badgeCode)) {
+            return true;
         }
 
-        $image = Http::get($this->data['image']);
+        $resolvedUrl = app(PublicHttpUrlResolver::class)->resolve($imageUrl);
 
-        if (! $image->successful()) {
-            return;
+        if ($resolvedUrl === null) {
+            $this->notifyBadgeImageUploadFailed();
+
+            return false;
         }
 
-        $contentType = $image->header('content-type');
+        $image = OutboundHttp::request()
+            ->withOptions([
+                'allow_redirects' => false,
+                'curl' => [
+                    CURLOPT_RESOLVE => [$resolvedUrl->curlResolveEntry()],
+                    CURLOPT_PROXY => '',
+                    CURLOPT_NOPROXY => '*',
+                    CURLOPT_NOPROGRESS => false,
+                    CURLOPT_XFERINFOFUNCTION => static fn (
+                        mixed $handle,
+                        float $downloadSize,
+                        float $downloaded,
+                        float $uploadSize,
+                        float $uploaded,
+                    ): int => $downloaded > self::MAX_BADGE_IMAGE_BYTES ? 1 : 0,
+                ],
+            ])
+            ->get($resolvedUrl->url);
 
-        $gdImage = match ($contentType) {
-            'image/png' => imagecreatefrompng($this->data['image']),
-            'image/gif' => imagecreatefromgif($this->data['image']),
-            'image/jpeg' => imagecreatefromjpeg($this->data['image']),
-            default => false
-        };
+        if (! $image->successful() || strlen($image->body()) > self::MAX_BADGE_IMAGE_BYTES) {
+            $this->notifyBadgeImageUploadFailed();
+
+            return false;
+        }
+
+        $contentType = strtolower(trim(explode(';', $image->header('content-type'), 2)[0]));
+
+        try {
+            $gdImage = in_array($contentType, ['image/png', 'image/gif', 'image/jpeg'], true)
+                ? imagecreatefromstring($image->body())
+                : false;
+        } catch (Throwable) {
+            $gdImage = false;
+        }
 
         if ($gdImage === false) {
-            Notification::make()
-                ->icon('heroicon-o-exclamation-triangle')
-                ->iconColor('danger')
-                ->color('danger')
-                ->title(__('filament::resources.notifications.badge_image_upload_failed'))
-                ->send();
+            $this->notifyBadgeImageUploadFailed();
 
-            return;
+            return false;
         }
 
         $uploadPath = public_path(sprintf('%s%s%s.gif',
             rtrim(config('hotel.client.flash.relative_files_path'), '\//'),
             '/c_images/album1584/',
-            $this->data['code'],
+            $badgeCode,
         ));
 
-        imagegif($gdImage, $uploadPath);
+        try {
+            $saved = imagegif($gdImage, $uploadPath);
+        } finally {
+            imagedestroy($gdImage);
+        }
+
+        if (! $saved) {
+            $this->notifyBadgeImageUploadFailed();
+        }
+
+        return $saved;
+    }
+
+    private function badgeCode(): ?string
+    {
+        $code = $this->data['code'] ?? null;
+
+        if (! is_string($code)) {
+            return null;
+        }
+
+        $code = strtoupper(trim($code));
+
+        return preg_match('/\A[A-Z0-9_-]{1,64}\z/', $code) === 1 ? $code : null;
+    }
+
+    private function notifyBadgeImageUploadFailed(): void
+    {
+        Notification::make()
+            ->icon('heroicon-o-exclamation-triangle')
+            ->iconColor('danger')
+            ->color('danger')
+            ->title(__('filament::resources.notifications.badge_image_upload_failed'))
+            ->send();
     }
 
     /**

--- a/app/Support/PublicHttpUrlResolver.php
+++ b/app/Support/PublicHttpUrlResolver.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Support;
+
+use Closure;
+use Symfony\Component\HttpFoundation\IpUtils;
+
+final class PublicHttpUrlResolver
+{
+    /** @var Closure(string): list<string> */
+    private Closure $resolveHost;
+
+    /** @param (Closure(string): list<string>)|null $resolveHost */
+    public function __construct(?Closure $resolveHost = null)
+    {
+        $this->resolveHost = $resolveHost ?? $this->resolveDns(...);
+    }
+
+    public function resolve(string $url): ?ResolvedPublicUrl
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            return null;
+        }
+
+        $parts = parse_url($url);
+
+        if (! is_array($parts)
+            || ($parts['scheme'] ?? null) !== 'https'
+            || ! is_string($parts['host'] ?? null)
+            || isset($parts['user'])
+            || isset($parts['pass'])) {
+            return null;
+        }
+
+        $host = strtolower(rtrim($parts['host'], '.'));
+        $port = $parts['port'] ?? 443;
+
+        if ($host === '' || $port !== 443) {
+            return null;
+        }
+
+        $ips = filter_var($host, FILTER_VALIDATE_IP) !== false
+            ? [$host]
+            : ($this->resolveHost)($host);
+
+        if ($ips === [] || collect($ips)->contains(fn (string $ip): bool => ! $this->isPublicIp($ip))) {
+            return null;
+        }
+
+        return new ResolvedPublicUrl($url, $host, $port, $ips[0]);
+    }
+
+    /** @return list<string> */
+    private function resolveDns(string $host): array
+    {
+        if (preg_match('/^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/', $host) !== 1) {
+            return [];
+        }
+
+        $records = dns_get_record($host, DNS_A | DNS_AAAA);
+
+        if ($records === false) {
+            return [];
+        }
+
+        $ips = [];
+
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+
+            if (is_string($ip)) {
+                $ips[] = $ip;
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+
+    private function isPublicIp(string $ip): bool
+    {
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_GLOBAL_RANGE) !== false
+            && ! IpUtils::checkIp($ip, ['224.0.0.0/4', 'ff00::/8']);
+    }
+}

--- a/app/Support/ResolvedPublicUrl.php
+++ b/app/Support/ResolvedPublicUrl.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Support;
+
+final readonly class ResolvedPublicUrl
+{
+    public function __construct(
+        public string $url,
+        public string $host,
+        public int $port,
+        public string $ip,
+    ) {}
+
+    public function curlResolveEntry(): string
+    {
+        $ip = str_contains($this->ip, ':') ? "[{$this->ip}]" : $this->ip;
+
+        return "{$this->host}:{$this->port}:{$ip}";
+    }
+}

--- a/tests/Feature/Services/OutboundHttpTest.php
+++ b/tests/Feature/Services/OutboundHttpTest.php
@@ -5,6 +5,7 @@ use App\Rules\GoogleRecaptchaRule;
 use App\Services\FindRetrosService;
 use App\Services\IpLookupService;
 use App\Support\DiscordWebhookUrl;
+use App\Support\PublicHttpUrlResolver;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -26,6 +27,36 @@ test('discord webhook URLs are restricted to official HTTPS endpoints', function
         ->toBeFalse()
         ->and(DiscordWebhookUrl::isValid('https://discord.com@127.0.0.1/api/webhooks/123/token'))
         ->toBeFalse();
+});
+
+test('badge image URLs resolve only to public HTTPS destinations', function () {
+    $public = new PublicHttpUrlResolver(static fn (string $host): array => ['93.184.216.34']);
+    $private = new PublicHttpUrlResolver(static fn (string $host): array => ['127.0.0.1']);
+    $mixed = new PublicHttpUrlResolver(static fn (string $host): array => ['93.184.216.34', '10.0.0.1']);
+    $carrierGradeNat = new PublicHttpUrlResolver(static fn (string $host): array => ['100.64.0.1']);
+    $documentation = new PublicHttpUrlResolver(static fn (string $host): array => ['192.0.2.1']);
+    $multicast = new PublicHttpUrlResolver(static fn (string $host): array => ['224.0.0.1']);
+
+    expect($public->resolve('https://images.example.com/badge.gif'))
+        ->not->toBeNull()
+        ->and($public->resolve('https://8.8.8.8/badge.gif'))
+        ->not->toBeNull()
+        ->and($public->resolve('http://images.example.com/badge.gif'))
+        ->toBeNull()
+        ->and($public->resolve('https://images.example.com:8443/badge.gif'))
+        ->toBeNull()
+        ->and($public->resolve('https://user:pass@images.example.com/badge.gif'))
+        ->toBeNull()
+        ->and($private->resolve('https://internal.example.com/badge.gif'))
+        ->toBeNull()
+        ->and($mixed->resolve('https://mixed.example.com/badge.gif'))
+        ->toBeNull()
+        ->and($carrierGradeNat->resolve('https://carrier.example.com/badge.gif'))
+        ->toBeNull()
+        ->and($documentation->resolve('https://documentation.example.com/badge.gif'))
+        ->toBeNull()
+        ->and($multicast->resolve('https://multicast.example.com/badge.gif'))
+        ->toBeNull();
 });
 
 test('findretros uses encoded HTTPS requests and fails open on service errors', function () {


### PR DESCRIPTION
## Summary
- restrict remote badge images to DNS-validated public HTTPS destinations
- pin requests to the validated address, disable proxying and redirects, and cap downloads at 1 MiB
- decode fetched bytes once and stop badge updates when image storage fails
- validate and normalize badge codes before using them in paths or external-text keys

## Verification
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pint app/Filament/Pages/BadgePage.php app/Support/PublicHttpUrlResolver.php app/Support/ResolvedPublicUrl.php tests/Feature/Services/OutboundHttpTest.php`
- targeted Pest suite: 11 passed, 42 assertions
- full Pest suite: 147 passed, 426 assertions