### PR TITLE
fix: evaluate authorization against policy actors

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ use App\Models\User\Ban;
 use App\Models\User\ClaimedReferralLog;
 use App\Models\User\Referral;
 use App\Models\User\UserReferral;
+use App\Services\HousekeepingPermissionsService;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasName;
 use Filament\Panel;
@@ -428,7 +429,7 @@ class User extends Authenticatable implements FilamentUser, HasName
 
     public function canAccessPanel(Panel $panel): bool
     {
-        return hasHousekeepingPermission('can_access_housekeeping');
+        return app(HousekeepingPermissionsService::class)->allows($this, 'can_access_housekeeping');
     }
 
     public function getActivitylogOptions(): LogOptions

--- a/app/Policies/ActivityPolicy.php
+++ b/app/Policies/ActivityPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Services\HousekeepingPermissionsService;
 use Illuminate\Auth\Access\HandlesAuthorization;
 use Spatie\Activitylog\Models\Activity;
 
@@ -10,14 +11,16 @@ class ActivityPolicy
 {
     use HandlesAuthorization;
 
+    public function __construct(private readonly HousekeepingPermissionsService $permissions) {}
+
     public function viewAny(User $user): bool
     {
-        return hasHousekeepingPermission('view_activity_logs');
+        return $this->permissions->allows($user, 'view_activity_logs');
     }
 
     public function view(User $user, Activity $activity): bool
     {
-        return hasHousekeepingPermission('view_activity_logs');
+        return $this->permissions->allows($user, 'view_activity_logs');
     }
 
     public function create(User $user): bool

--- a/app/Policies/HousekeepingPolicy.php
+++ b/app/Policies/HousekeepingPolicy.php
@@ -3,11 +3,14 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Services\HousekeepingPermissionsService;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 abstract class HousekeepingPolicy
 {
     use HandlesAuthorization;
+
+    public function __construct(private readonly HousekeepingPermissionsService $permissions) {}
 
     /**
      * Housekeeping permission required to view and manage the resource.
@@ -24,91 +27,96 @@ abstract class HousekeepingPolicy
 
     public function viewAny(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function view(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function create(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function update(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function reorder(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function replicate(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function attach(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function detach(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function detachAny(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function associate(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function dissociate(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function dissociateAny(User $user): bool
     {
-        return hasHousekeepingPermission($this->permission());
+        return $this->allows($user, $this->permission());
     }
 
     public function delete(User $user): bool
     {
-        return hasHousekeepingPermission($this->deletePermission());
+        return $this->allows($user, $this->deletePermission());
     }
 
     public function deleteAny(User $user): bool
     {
-        return hasHousekeepingPermission($this->deletePermission());
+        return $this->allows($user, $this->deletePermission());
     }
 
     public function restore(User $user): bool
     {
-        return hasHousekeepingPermission($this->deletePermission());
+        return $this->allows($user, $this->deletePermission());
     }
 
     public function restoreAny(User $user): bool
     {
-        return hasHousekeepingPermission($this->deletePermission());
+        return $this->allows($user, $this->deletePermission());
     }
 
     public function forceDelete(User $user): bool
     {
-        return hasHousekeepingPermission($this->deletePermission());
+        return $this->allows($user, $this->deletePermission());
     }
 
     public function forceDeleteAny(User $user): bool
     {
-        return hasHousekeepingPermission($this->deletePermission());
+        return $this->allows($user, $this->deletePermission());
+    }
+
+    protected function allows(User $user, string $permission): bool
+    {
+        return $this->permissions->allows($user, $permission);
     }
 }

--- a/app/Policies/WebsiteArticlePolicy.php
+++ b/app/Policies/WebsiteArticlePolicy.php
@@ -18,6 +18,6 @@ class WebsiteArticlePolicy extends HousekeepingPolicy
 
     public function update(User $user): bool
     {
-        return hasHousekeepingPermission('edit_article');
+        return $this->allows($user, 'edit_article');
     }
 }

--- a/app/Policies/WebsiteHelpCenterTicketPolicy.php
+++ b/app/Policies/WebsiteHelpCenterTicketPolicy.php
@@ -4,18 +4,21 @@ namespace App\Policies;
 
 use App\Models\Help\WebsiteHelpCenterTicket;
 use App\Models\User;
+use App\Services\PermissionsService;
 use Illuminate\Auth\Access\HandlesAuthorization;
 
 class WebsiteHelpCenterTicketPolicy
 {
     use HandlesAuthorization;
 
+    public function __construct(private readonly PermissionsService $permissions) {}
+
     /**
      * The ticket overview lists every user's tickets, so it is staff-only.
      */
     public function viewAny(User $user): bool
     {
-        return hasPermission('manage_website_tickets');
+        return $this->permissions->allows($user, 'manage_website_tickets');
     }
 
     public function view(User $user, WebsiteHelpCenterTicket $ticket): bool
@@ -25,11 +28,13 @@ class WebsiteHelpCenterTicketPolicy
 
     public function update(User $user, WebsiteHelpCenterTicket $ticket): bool
     {
-        return $ticket->user_id === $user->id || hasPermission('manage_website_tickets');
+        return $ticket->user_id === $user->id
+            || $this->permissions->allows($user, 'manage_website_tickets');
     }
 
     public function delete(User $user, WebsiteHelpCenterTicket $ticket): bool
     {
-        return $ticket->user_id === $user->id || hasPermission('delete_website_tickets');
+        return $ticket->user_id === $user->id
+            || $this->permissions->allows($user, 'delete_website_tickets');
     }
 }

--- a/app/Services/HousekeepingPermissionsService.php
+++ b/app/Services/HousekeepingPermissionsService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\User;
 use App\Models\WebsiteHousekeepingPermission;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -25,13 +26,22 @@ class HousekeepingPermissionsService
 
     public function getOrDefault(string $permissionName, bool $default = false): bool
     {
+        $user = auth()->user();
+
+        return $user instanceof User
+            ? $this->allows($user, $permissionName, $default)
+            : $default;
+    }
+
+    public function allows(User $user, string $permissionName, bool $default = false): bool
+    {
         $permissions = $this->permissions();
 
         if (! $permissions->has($permissionName)) {
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $permissions->get($permissionName);
+        return $user->rank >= (int) $permissions->get($permissionName);
     }
 
     public static function clearCache(): void

--- a/app/Services/PermissionsService.php
+++ b/app/Services/PermissionsService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Miscellaneous\WebsitePermission;
+use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -25,13 +26,22 @@ class PermissionsService
 
     public function getOrDefault(string $permissionName, bool $default = false): bool
     {
+        $user = auth()->user();
+
+        return $user instanceof User
+            ? $this->allows($user, $permissionName, $default)
+            : $default;
+    }
+
+    public function allows(User $user, string $permissionName, bool $default = false): bool
+    {
         $permissions = $this->permissions();
 
         if (! $permissions->has($permissionName)) {
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $permissions->get($permissionName);
+        return $user->rank >= (int) $permissions->get($permissionName);
     }
 
     public static function clearCache(): void

--- a/tests/Feature/HousekeepingAccessTest.php
+++ b/tests/Feature/HousekeepingAccessTest.php
@@ -1,6 +1,10 @@
 <?php
 
+use App\Models\Miscellaneous\WebsitePermission;
 use App\Models\User;
+use App\Models\WebsiteHousekeepingPermission;
+use App\Policies\BanPolicy;
+use App\Policies\WebsiteHelpCenterTicketPolicy;
 
 test('guests are redirected away from the housekeeping panel', function () {
     installHotel();
@@ -14,4 +18,29 @@ test('users without the housekeeping permission are forbidden', function () {
     $user = User::factory()->create();
 
     $this->actingAs($user)->get('/housekeeping')->assertForbidden();
+});
+
+test('policies evaluate the explicit actor instead of global authentication', function () {
+    installHotel();
+
+    WebsiteHousekeepingPermission::query()->updateOrCreate(
+        ['permission' => 'manage_bans'],
+        ['min_rank' => 5, 'description' => 'Manage bans'],
+    );
+    WebsitePermission::query()->updateOrCreate(
+        ['permission' => 'manage_website_tickets'],
+        ['min_rank' => 5, 'description' => 'Manage tickets'],
+    );
+
+    $signedInUser = User::factory()->create(['rank' => 1]);
+    $explicitActor = User::factory()->create(['rank' => 7]);
+    $this->actingAs($signedInUser);
+
+    $banPolicy = app(BanPolicy::class);
+    $ticketPolicy = app(WebsiteHelpCenterTicketPolicy::class);
+
+    expect($banPolicy->viewAny($explicitActor))->toBeTrue()
+        ->and($banPolicy->viewAny($signedInUser))->toBeFalse()
+        ->and($ticketPolicy->viewAny($explicitActor))->toBeTrue()
+        ->and($ticketPolicy->viewAny($signedInUser))->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- evaluate website and housekeeping permission thresholds against explicit users
- make resource, activity, article, and ticket policies honor Laravel's actor argument
- make Filament panel access evaluate the user instance instead of global auth
- preserve existing helpers as authenticated-user adapters for UI call sites

## Verification
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- scoped `vendor/bin/pint` on changed PHP files
- policy and ticket tests: 9 passed, 17 assertions
- full Pest suite: 142 passed, 404 assertions