### PR TITLE
refactor: enable level eight static analysis

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -28,10 +28,8 @@ class CreateNewUser implements CreatesNewUsers
      */
     public function create(array $input): User
     {
-        $ip = request()->ip();
-
-        $this->ensureRegistrationAllowed($ip);
-        $this->validate($input);
+        $ip = $this->registrationIp(request()->ip());
+        $input = $this->validate($input);
 
         $user = $this->createUser($input, $ip);
 
@@ -40,19 +38,19 @@ class CreateNewUser implements CreatesNewUsers
 
         if (setting('enable_discord_webhook') === '1') {
             // After the response, so registration never waits on Discord.
-            SendRegisteredUserWebhook::dispatchAfterResponse($user->username, $user->ip_register, $user->mail);
+            SendRegisteredUserWebhook::dispatchAfterResponse($user->username, $user->ip_register, $input['mail']);
         }
 
         return $user;
     }
 
-    private function ensureRegistrationAllowed(?string $ip): void
+    private function registrationIp(?string $ip): string
     {
         if ((setting('disable_registration') ?: '0') == '1') {
             throw ValidationException::withMessages(['registration' => __('Registration is disabled.')]);
         }
 
-        if (! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)) {
+        if (! is_string($ip) || filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6) === false) {
             throw ValidationException::withMessages(['registration' => __('Your IP address seems to be invalid')]);
         }
 
@@ -64,6 +62,8 @@ class CreateNewUser implements CreatesNewUsers
         if ($matchingIpCount >= (int) (setting('max_accounts_per_ip') ?: 99)) {
             throw ValidationException::withMessages(['registration' => __('You have reached the max amount of allowed account')]);
         }
+
+        return $ip;
     }
 
     /**
@@ -132,7 +132,7 @@ class CreateNewUser implements CreatesNewUsers
     /**
      * @param  array<string, mixed>  $inputs
      *
-     * @return array<string, mixed>
+     * @return array{username: string, mail: string, password: string, beta_code?: string, referral_code?: string}
      */
     private function validate(array $inputs): array
     {
@@ -141,6 +141,7 @@ class CreateNewUser implements CreatesNewUsers
             'mail' => ['required', 'string', 'email', 'max:255', Rule::unique('users')],
             'password' => $this->passwordRules(),
             'beta_code' => ['sometimes', 'string', new BetaCodeRule],
+            'referral_code' => ['sometimes', 'string', 'max:255'],
             'terms' => ['required', 'accepted'],
             'g-recaptcha-response' => ['sometimes', 'string', new GoogleRecaptchaRule],
             'cf-turnstile-response' => [app(Turnstile::class)],
@@ -151,6 +152,36 @@ class CreateNewUser implements CreatesNewUsers
             'g-recaptcha-response.string' => __('The google recaptcha was submitted with an invalid type'),
         ];
 
-        return Validator::make($inputs, $rules, $messages)->validate();
+        $validated = Validator::make($inputs, $rules, $messages)->validate();
+
+        if (! is_string($validated['username'] ?? null)
+            || ! is_string($validated['mail'] ?? null)
+            || ! is_string($validated['password'] ?? null)) {
+            throw new \UnexpectedValueException('Registration validation returned an invalid payload.');
+        }
+
+        $betaCode = $validated['beta_code'] ?? null;
+        $referralCode = $validated['referral_code'] ?? null;
+
+        if (($betaCode !== null && ! is_string($betaCode))
+            || ($referralCode !== null && ! is_string($referralCode))) {
+            throw new \UnexpectedValueException('Registration validation returned invalid optional values.');
+        }
+
+        $result = [
+            'username' => $validated['username'],
+            'mail' => $validated['mail'],
+            'password' => $validated['password'],
+        ];
+
+        if ($betaCode !== null) {
+            $result['beta_code'] = $betaCode;
+        }
+
+        if ($referralCode !== null) {
+            $result['referral_code'] = $referralCode;
+        }
+
+        return $result;
     }
 }

--- a/app/Actions/Fortify/RedirectIfTwoFactorAuthenticatable.php
+++ b/app/Actions/Fortify/RedirectIfTwoFactorAuthenticatable.php
@@ -97,17 +97,13 @@ class RedirectIfTwoFactorAuthenticatable
                 $this->convertUserPassword($user, $request->input('password'));
             }
 
-            if (! $user || ! $this->guard->getProvider()->validateCredentials($user, ['password' => $request->password])) {
+            if (! $user instanceof User || ! $this->guard->getProvider()->validateCredentials($user, ['password' => $request->password])) {
                 $this->fireFailedEvent($request, $user);
 
                 $this->throwFailedAuthenticationException($request);
             }
 
             $this->validate($request);
-
-            $user = User::select('id', 'password', 'rank')
-                ->where('username', '=', $request->input('username'))
-                ->first();
 
             if (setting('maintenance_enabled') === '1' && setting('min_maintenance_login_rank') > $user->rank) {
                 throw ValidationException::withMessages([

--- a/app/Actions/Shop/FulfillPackage.php
+++ b/app/Actions/Shop/FulfillPackage.php
@@ -33,7 +33,13 @@ class FulfillPackage
         $package->loadMissing('items');
 
         foreach ($package->items as $item) {
-            $quantity = (int) $item->pivot->quantity;
+            $pivot = $item->pivot;
+
+            if ($pivot === null) {
+                throw self::misconfigured($item);
+            }
+
+            $quantity = $pivot->quantity;
 
             match ($item->type) {
                 'currency' => $this->giveCurrency($user, $item, $quantity),

--- a/app/Console/Commands/ImportAdsData.php
+++ b/app/Console/Commands/ImportAdsData.php
@@ -21,7 +21,7 @@ class ImportAdsData extends Command
     {
         $adsPath = $settingsService->getOrDefault('ads_path_filesystem');
 
-        if (! $this->validatePath($adsPath)) {
+        if (! is_string($adsPath) || ! $this->validatePath($adsPath)) {
             return;
         }
 

--- a/app/Console/Commands/ImportBadgeData.php
+++ b/app/Console/Commands/ImportBadgeData.php
@@ -30,7 +30,7 @@ class ImportBadgeData extends Command
     {
         $jsonPath = $this->settingsService->getOrDefault('nitro_external_texts_file');
 
-        if (! $this->validateJsonFile($jsonPath)) {
+        if (! is_string($jsonPath) || ! $this->validateJsonFile($jsonPath)) {
             return;
         }
 

--- a/app/Filament/Filters/DateRangeFilter.php
+++ b/app/Filament/Filters/DateRangeFilter.php
@@ -5,25 +5,28 @@ namespace App\Filament\Filters;
 use Filament\Forms\Components\DatePicker;
 use Filament\Tables\Filters\Filter;
 use Illuminate\Database\Eloquent\Builder;
+use InvalidArgumentException;
 
 class DateRangeFilter extends Filter
 {
     public static function make(?string $name = null): static
     {
+        $column = $name ?? throw new InvalidArgumentException('Date range filters require a column name.');
+
         return parent::make($name)
             ->schema([
-                DatePicker::make("{$name}_from"),
-                DatePicker::make("{$name}_until"),
+                DatePicker::make("{$column}_from"),
+                DatePicker::make("{$column}_until"),
             ])
-            ->query(function (Builder $query, array $data) use (&$name): Builder {
+            ->query(function (Builder $query, array $data) use ($column): Builder {
                 return $query
                     ->when(
-                        $data["{$name}_from"],
-                        fn (Builder $query, $date): Builder => $query->whereDate($name, '>=', $date),
+                        $data["{$column}_from"] ?? null,
+                        fn (Builder $query, $date): Builder => $query->whereDate($column, '>=', $date),
                     )
                     ->when(
-                        $data["{$name}_until"],
-                        fn (Builder $query, $date): Builder => $query->whereDate($name, '<=', $date),
+                        $data["{$column}_until"] ?? null,
+                        fn (Builder $query, $date): Builder => $query->whereDate($column, '<=', $date),
                     );
             });
     }

--- a/app/Filament/Pages/BadgePage.php
+++ b/app/Filament/Pages/BadgePage.php
@@ -41,7 +41,7 @@ class BadgePage extends Page
 
     public static function canAccess(): bool
     {
-        return auth()->user()->can('view::admin::' . static::$roleName);
+        return auth()->user()?->can('view::admin::' . static::$roleName) ?? false;
     }
 
     public function getTitle(): string|Htmlable
@@ -61,7 +61,7 @@ class BadgePage extends Page
                             ->label(__('filament::resources.inputs.badge_code'))
                             ->helperText(__('filament::resources.helpers.badge_code_helper'))
                             ->afterStateUpdated(function (?string $state, Set $set) {
-                                $set('code', strtoupper($state));
+                                $set('code', is_string($state) ? strtoupper($state) : null);
                             })
                             ->suffixAction(fn (): PageAction => PageAction::make('search')->icon('heroicon-o-magnifying-glass')->action(fn () => $this->searchBadgesByCode()),
                             ),
@@ -248,7 +248,13 @@ class BadgePage extends Page
             return;
         }
 
-        $this->data['image'] = $externalTextsParser->getBadgeImageUrl($this->data['code']);
+        $badgeCode = $this->data['code'] ?? null;
+
+        if (! is_string($badgeCode)) {
+            return;
+        }
+
+        $this->data['image'] = $externalTextsParser->getBadgeImageUrl($badgeCode);
         $this->badgeWasPreviouslyCreated = true;
 
         Notification::make()

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -21,6 +21,6 @@ class Dashboard extends FilamentDashboard
 
     public static function canAccess(): bool
     {
-        return auth()->user()->can('view::admin::' . static::$roleName);
+        return auth()->user()?->can('view::admin::' . static::$roleName) ?? false;
     }
 }

--- a/app/Filament/Pages/Login.php
+++ b/app/Filament/Pages/Login.php
@@ -41,10 +41,11 @@ class Login extends \Filament\Auth\Pages\Login
         }
 
         $user = Filament::auth()->user();
+        $panel = Filament::getCurrentOrDefaultPanel();
 
         if (
             ($user instanceof FilamentUser) &&
-            (! $user->canAccessPanel(Filament::getCurrentOrDefaultPanel()))
+            ($panel === null || ! $user->canAccessPanel($panel))
         ) {
             Filament::auth()->logout();
 

--- a/app/Filament/Resources/Atom/Articles/ArticleResource.php
+++ b/app/Filament/Resources/Atom/Articles/ArticleResource.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\Atom\Articles\Pages\ViewArticle;
 use App\Filament\Resources\Atom\Articles\RelationManagers\TagsRelationManager;
 use App\Filament\Traits\TranslatableResource;
 use App\Models\Articles\WebsiteArticle;
+use App\Support\AuthenticatedUser;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -93,7 +94,7 @@ class ArticleResource extends Resource
                                 ->columnSpan('full'),
 
                             Hidden::make('user_id')
-                                ->default(fn () => auth()->check() ? auth()->user()->id : null),
+                                ->default(fn (): int => AuthenticatedUser::current()->id),
                         ]),
 
                     Tab::make(__('filament::resources.tabs.Configurations'))

--- a/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogPageForm.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Forms/CatalogPageForm.php
@@ -70,6 +70,8 @@ class CatalogPageForm
 
     public static function sanitizeTag(?string $value): string
     {
-        return $value ? strtolower(preg_replace('/[^a-z]/', '', $value)) : '';
+        $sanitized = $value ? preg_replace('/[^a-z]/', '', $value) : null;
+
+        return is_string($sanitized) ? strtolower($sanitized) : '';
     }
 }

--- a/app/Filament/Resources/User/PlusBans/Pages/ManagePlusBans.php
+++ b/app/Filament/Resources/User/PlusBans/Pages/ManagePlusBans.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\User\PlusBans\Pages;
 
 use App\Filament\Resources\User\PlusBans\PlusBanResource;
+use App\Support\AuthenticatedUser;
 use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ManageRecords;
 
@@ -15,7 +16,7 @@ class ManagePlusBans extends ManageRecords
         return [
             CreateAction::make()
                 ->mutateDataUsing(function (array $data): array {
-                    $data['added_by'] = auth()->user()->username;
+                    $data['added_by'] = AuthenticatedUser::current()->username;
                     $data['added_date'] = time();
 
                     return $data;

--- a/app/Filament/Resources/User/Users/Pages/EditUser.php
+++ b/app/Filament/Resources/User/Users/Pages/EditUser.php
@@ -10,6 +10,7 @@ use App\Emulator\Emulator;
 use App\Enums\CurrencyTypes;
 use App\Filament\Resources\User\Users\UserResource;
 use App\Models\User;
+use App\Support\AuthenticatedUser;
 use Filament\Actions\DeleteAction;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
@@ -47,7 +48,7 @@ class EditUser extends EditRecord
         $data = $this->getSchema('form')?->getState()
             ?? throw new LogicException('The user edit form schema is not registered.');
 
-        if ($data['rank'] > auth()->user()->rank) {
+        if ($data['rank'] > AuthenticatedUser::current()->rank) {
             Notification::make()
                 ->danger()
                 ->title(__('You cannot edit this user!'))
@@ -189,7 +190,7 @@ class EditUser extends EditRecord
         if ($data['rank'] == $user->rank) {
             return;
         }
-        if ($data['rank'] > auth()->user()->rank) {
+        if ($data['rank'] > AuthenticatedUser::current()->rank) {
             return;
         }
 

--- a/app/Filament/Resources/User/Users/UserResource.php
+++ b/app/Filament/Resources/User/Users/UserResource.php
@@ -17,6 +17,7 @@ use App\Filament\Traits\TranslatableResource;
 use App\Models\Community\Staff\WebsiteTeam;
 use App\Models\Game\Permission;
 use App\Models\User;
+use App\Support\AuthenticatedUser;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
 use Filament\Forms\Components\DateTimePicker;
@@ -191,7 +192,7 @@ class UserResource extends Resource
                                         Select::make('rank')
                                             ->native(false)
                                             ->label(__('filament::resources.inputs.rank'))
-                                            ->options(Permission::where('id', '<', auth()->user()->rank)->get()->pluck('rank_name', 'id')),
+                                            ->options(Permission::where('id', '<', AuthenticatedUser::current()->rank)->get()->pluck('rank_name', 'id')),
 
                                         Toggle::make('hidden_staff')
                                             ->label(__('filament::resources.inputs.is_hidden'))

--- a/app/Http/Controllers/Articles/ArticleController.php
+++ b/app/Http/Controllers/Articles/ArticleController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Articles\WebsiteArticle;
 use App\Services\Articles\ArticleService;
 use App\Services\Articles\ReactionService;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -48,7 +49,7 @@ class ArticleController extends Controller
 
     public function toggleReaction(WebsiteArticle $article, Request $request): JsonResponse
     {
-        $response = $this->reactionService->toggleReaction($article, Auth::user(), $request);
+        $response = $this->reactionService->toggleReaction($article, AuthenticatedUser::from($request), $request);
 
         return response()->json($response);
     }

--- a/app/Http/Controllers/Badge/BadgeController.php
+++ b/app/Http/Controllers/Badge/BadgeController.php
@@ -6,6 +6,7 @@ use App\Actions\Badge\CreateDrawnBadge;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Badge\BadgePurchaseRequest;
 use App\Services\SettingsService;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\JsonResponse;
 use Illuminate\View\View;
 
@@ -26,7 +27,7 @@ class BadgeController extends Controller
     public function buy(BadgePurchaseRequest $request, CreateDrawnBadge $createDrawnBadge): JsonResponse
     {
         $validated = $request->validated();
-        $badge = $createDrawnBadge->execute($request->user(), [
+        $badge = $createDrawnBadge->execute(AuthenticatedUser::from($request), [
             'badge_data' => (string) $validated['badge_data'],
             'badge_name' => (string) $validated['badge_name'],
             'badge_description' => (string) $validated['badge_description'],

--- a/app/Http/Controllers/Client/FlashController.php
+++ b/app/Http/Controllers/Client/FlashController.php
@@ -3,19 +3,22 @@
 namespace App\Http\Controllers\Client;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
+use App\Support\AuthenticatedUser;
+use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class FlashController extends Controller
 {
-    public function __invoke(): View
+    public function __invoke(Request $request): View
     {
-        Auth::user()->update([
-            'ip_current' => request()->ip(),
+        $user = AuthenticatedUser::from($request);
+
+        $user->update([
+            'ip_current' => $request->ip(),
         ]);
 
         return view('client.flash', [
-            'sso' => Auth::user()->ssoTicket(),
+            'sso' => $user->ssoTicket(),
         ]);
     }
 }

--- a/app/Http/Controllers/Client/NitroController.php
+++ b/app/Http/Controllers/Client/NitroController.php
@@ -3,19 +3,22 @@
 namespace App\Http\Controllers\Client;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
+use App\Support\AuthenticatedUser;
+use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class NitroController extends Controller
 {
-    public function __invoke(): View
+    public function __invoke(Request $request): View
     {
-        Auth::user()->update([
-            'ip_current' => request()->ip(),
+        $user = AuthenticatedUser::from($request);
+
+        $user->update([
+            'ip_current' => $request->ip(),
         ]);
 
         return view('client.nitro', [
-            'sso' => Auth::user()->ssoTicket(),
+            'sso' => $user->ssoTicket(),
         ]);
     }
 }

--- a/app/Http/Controllers/Community/Staff/StaffApplicationsController.php
+++ b/app/Http/Controllers/Community/Staff/StaffApplicationsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Community\Staff;
 use App\Http\Controllers\Controller;
 use App\Models\Community\Staff\WebsiteOpenPosition;
 use App\Models\Community\Staff\WebsiteStaffApplications;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -41,9 +42,12 @@ class StaffApplicationsController extends Controller
             'content' => ['required', 'string', 'min:10'],
         ]);
 
-        $user = $request->user();
+        $rankId = $position->permission_id;
+        abort_if($rankId === null, 404);
 
-        if ($user->hasAppliedForPosition($position->permission_id)) {
+        $user = AuthenticatedUser::from($request);
+
+        if ($user->hasAppliedForPosition($rankId)) {
             return back()->withErrors([
                 'content' => __('You have already applied for this position.'),
             ])->withInput();
@@ -51,7 +55,7 @@ class StaffApplicationsController extends Controller
 
         WebsiteStaffApplications::create([
             'user_id' => $user->id,
-            'rank_id' => $position->permission_id,
+            'rank_id' => $rankId,
             'content' => $validated['content'],
         ]);
 

--- a/app/Http/Controllers/Community/Staff/WebsiteTeamApplicationsController.php
+++ b/app/Http/Controllers/Community/Staff/WebsiteTeamApplicationsController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Community\Staff;
 use App\Http\Controllers\Controller;
 use App\Models\Community\Staff\WebsiteOpenPosition;
 use App\Models\Community\Staff\WebsiteStaffApplications;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -57,9 +58,12 @@ class WebsiteTeamApplicationsController extends Controller
             'content' => ['required', 'string', 'min:10'],
         ]);
 
-        $user = $request->user();
+        $teamId = $position->team_id;
+        abort_if($teamId === null, 404);
 
-        if ($user->hasAppliedForTeam($position->team_id)) {
+        $user = AuthenticatedUser::from($request);
+
+        if ($user->hasAppliedForTeam($teamId)) {
             return back()->withErrors([
                 'content' => __('You have already applied for this team.'),
             ]);
@@ -67,7 +71,7 @@ class WebsiteTeamApplicationsController extends Controller
 
         WebsiteStaffApplications::create([
             'user_id' => $user->id,
-            'team_id' => $position->team_id,
+            'team_id' => $teamId,
             'content' => $request->string('content'),
         ]);
 

--- a/app/Http/Controllers/Help/TicketController.php
+++ b/app/Http/Controllers/Help/TicketController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\WebsiteTicketFormRequest;
 use App\Models\Help\WebsiteHelpCenterCategory;
 use App\Models\Help\WebsiteHelpCenterTicket;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
@@ -31,7 +32,7 @@ class TicketController extends Controller
 
     public function store(WebsiteTicketFormRequest $request): RedirectResponse
     {
-        Auth::user()->tickets()->create($request->validated());
+        AuthenticatedUser::from($request)->tickets()->create($request->validated());
 
         return redirect()->back()->with('success', __('Ticket submitted!'));
     }

--- a/app/Http/Controllers/Help/TicketReplyController.php
+++ b/app/Http/Controllers/Help/TicketReplyController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\WebsiteTicketReplyFormRequest;
 use App\Models\Help\WebsiteHelpCenterTicket;
 use App\Models\Help\WebsiteHelpCenterTicketReply;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 
 class TicketReplyController extends Controller
@@ -26,7 +27,7 @@ class TicketReplyController extends Controller
 
         $data = $request->validated();
         $ticket->replies()->create([
-            'user_id' => $request->user()->id,
+            'user_id' => AuthenticatedUser::from($request)->id,
             'content' => $data['content'],
         ]);
 

--- a/app/Http/Controllers/Home/ItemController.php
+++ b/app/Http/Controllers/Home/ItemController.php
@@ -36,7 +36,15 @@ class ItemController extends Controller
     {
         $item = $user->homeItems()->defaultRelationships()->find($itemId);
 
-        if (! $item) {
+        if ($item === null) {
+            return $this->jsonResponse([
+                'message' => __('Home item not found.'),
+            ], 404);
+        }
+
+        $homeItem = $item->homeItem;
+
+        if ($homeItem === null) {
             return $this->jsonResponse([
                 'message' => __('Home item not found.'),
             ], 404);
@@ -45,7 +53,7 @@ class ItemController extends Controller
         $item->setWidgetContent($user);
 
         return $this->jsonResponse([
-            'name' => $item->homeItem->name,
+            'name' => $homeItem->name,
             'widget_type' => $item->widget_type,
             'content' => $item->content,
         ]);

--- a/app/Http/Controllers/Home/MessageController.php
+++ b/app/Http/Controllers/Home/MessageController.php
@@ -5,13 +5,14 @@ namespace App\Http\Controllers\Home;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Home\HomeMessageRequest;
 use App\Models\User;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\JsonResponse;
 
 class MessageController extends Controller
 {
     public function store(User $user, HomeMessageRequest $request): JsonResponse
     {
-        $authUser = $request->user();
+        $authUser = AuthenticatedUser::from($request);
 
         if ($authUser->sentHomeMessages()->where('created_at', '>', now()->subMinute())->exists()) {
             return $this->jsonResponse([

--- a/app/Http/Controllers/Home/RatingController.php
+++ b/app/Http/Controllers/Home/RatingController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Home;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Home\HomeRatingRequest;
 use App\Models\User;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\JsonResponse;
 
 class RatingController extends Controller
@@ -12,7 +13,7 @@ class RatingController extends Controller
     public function store(User $user, HomeRatingRequest $request): JsonResponse
     {
         $user->homeRatings()->updateOrCreate(
-            ['user_id' => $request->user()->id],
+            ['user_id' => AuthenticatedUser::from($request)->id],
             ['rating' => $request->validated('rating')],
         );
 

--- a/app/Http/Controllers/Home/ShopController.php
+++ b/app/Http/Controllers/Home/ShopController.php
@@ -8,6 +8,7 @@ use App\Models\Home\HomeCategory;
 use App\Models\Home\HomeItem;
 use App\Models\Home\UserHomeItem;
 use App\Models\User;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 
@@ -57,7 +58,7 @@ class ShopController extends Controller
 
     public function balance(): JsonResponse
     {
-        $user = Auth::user();
+        $user = AuthenticatedUser::current();
 
         return $this->jsonResponse([
             'balance' => [

--- a/app/Http/Controllers/Miscellaneous/InstallationController.php
+++ b/app/Http/Controllers/Miscellaneous/InstallationController.php
@@ -28,7 +28,7 @@ class InstallationController extends Controller
             'installation_key' => ['required', 'string', 'max:255', new ValidateInstallationKeyRule],
         ]);
 
-        WebsiteInstallation::first()->update([
+        $this->installation()->update([
             'step' => 1,
             'user_ip' => $request->ip(),
         ]);
@@ -57,21 +57,23 @@ class InstallationController extends Controller
     {
         $this->updateSettings($request);
 
-        WebsiteInstallation::first()->increment('step');
+        $installation = $this->installation();
+        $installation->increment('step');
 
-        return to_route('installation.show-step', WebsiteInstallation::first()->step);
+        return to_route('installation.show-step', $installation->step);
     }
 
     public function previousStep(): RedirectResponse
     {
-        WebsiteInstallation::first()->decrement('step');
+        $installation = $this->installation();
+        $installation->decrement('step');
 
-        return to_route('installation.show-step', WebsiteInstallation::first()->step);
+        return to_route('installation.show-step', $installation->step);
     }
 
     public function restartInstallation(): RedirectResponse
     {
-        WebsiteInstallation::first()->update([
+        $this->installation()->update([
             'step' => 0,
             'installation_key' => Str::uuid(),
             'user_ip' => null,
@@ -112,6 +114,11 @@ class InstallationController extends Controller
         }
 
         // Cache will be automatically cleared by WebsiteSetting model events
+    }
+
+    private function installation(): WebsiteInstallation
+    {
+        return WebsiteInstallation::query()->oldest('id')->firstOrFail();
     }
 
     /** @return Collection<int, WebsiteSetting> */

--- a/app/Http/Controllers/Shop/PaypalController.php
+++ b/app/Http/Controllers/Shop/PaypalController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\AccountTopupFormRequest;
 use App\Models\Shop\WebsitePaypalTransaction;
 use App\Models\User;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -36,7 +37,7 @@ class PaypalController extends Controller
             return $this->orderCreationFailed($response);
         }
 
-        $request->user()->transactions()->create([
+        AuthenticatedUser::from($request)->transactions()->create([
             'transaction_id' => $orderId,
             'amount' => 0,
         ]);
@@ -107,7 +108,7 @@ class PaypalController extends Controller
             'token' => 'required',
         ]);
 
-        $user = $request->user();
+        $user = AuthenticatedUser::from($request);
 
         $transaction = $user->transactions()->where('transaction_id', $request['token'])->first();
         if ($transaction === null) {
@@ -201,7 +202,7 @@ class PaypalController extends Controller
             'token' => 'required',
         ]);
 
-        $transaction = $request->user()->transactions()->where('transaction_id', $request['token'])->first();
+        $transaction = AuthenticatedUser::from($request)->transactions()->where('transaction_id', $request['token'])->first();
         if ($transaction !== null) {
             $transaction->update([
                 'status' => self::STATUS_CANCELLED,

--- a/app/Http/Controllers/Shop/ShopController.php
+++ b/app/Http/Controllers/Shop/ShopController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Shop\PurchasePackageRequest;
 use App\Models\Shop\WebsiteShopCategory;
 use App\Models\Shop\WebsiteShopPackage;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
@@ -30,7 +31,7 @@ class ShopController extends Controller
     public function purchasePackage(WebsiteShopPackage $package, PurchasePackageRequest $request, PurchaseShopPackage $purchaseShopPackage): RedirectResponse
     {
         try {
-            $message = $purchaseShopPackage->execute($request->user(), $package, $request->input('receiver'));
+            $message = $purchaseShopPackage->execute(AuthenticatedUser::from($request), $package, $request->input('receiver'));
         } catch (ShopPurchaseException $exception) {
             return to_route('shop.index')->withErrors(['message' => $exception->getMessage()]);
         }

--- a/app/Http/Controllers/Shop/ShopVoucherController.php
+++ b/app/Http/Controllers/Shop/ShopVoucherController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\ShopVoucherFormRequest;
 use App\Models\Shop\WebsiteShopVoucher;
 use App\Models\User;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\DB;
 
@@ -13,7 +14,7 @@ class ShopVoucherController extends Controller
 {
     public function __invoke(ShopVoucherFormRequest $request): RedirectResponse
     {
-        $user = $request->user();
+        $user = AuthenticatedUser::from($request);
         $voucher = WebsiteShopVoucher::where('code', $request->string('code'))->first();
 
         if ($voucher === null || ! $this->isActive($voucher)) {

--- a/app/Http/Controllers/User/AccountSettingsController.php
+++ b/app/Http/Controllers/User/AccountSettingsController.php
@@ -6,9 +6,9 @@ use App\Contracts\Rcon;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\AccountSettingsFormRequest;
 use App\Services\User\SessionService;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
 
 class AccountSettingsController extends Controller
@@ -18,7 +18,7 @@ class AccountSettingsController extends Controller
     public function edit(): View
     {
         return view('user.settings.account', [
-            'user' => Auth::user()->load('settings:allow_name_change'),
+            'user' => AuthenticatedUser::current()->load('settings:allow_name_change'),
         ]);
     }
 
@@ -33,11 +33,7 @@ class AccountSettingsController extends Controller
 
     public function update(AccountSettingsFormRequest $request): RedirectResponse
     {
-        $user = Auth::user();
-
-        if ($user === null) {
-            return redirect()->back()->withErrors('User not found');
-        }
+        $user = AuthenticatedUser::from($request);
 
         if (! $this->rconService->isConnected() && $user->online) {
             return back()->withErrors('You must be offline to change your account settings');

--- a/app/Http/Controllers/User/PasswordSettingsController.php
+++ b/app/Http/Controllers/User/PasswordSettingsController.php
@@ -4,8 +4,8 @@ namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\PasswordSettingsFormRequest;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\View\View;
 
@@ -18,7 +18,7 @@ class PasswordSettingsController extends Controller
 
     public function update(PasswordSettingsFormRequest $request): RedirectResponse
     {
-        Auth::user()->update([
+        AuthenticatedUser::from($request)->update([
             'password' => Hash::make($request->input('password')),
         ]);
 

--- a/app/Http/Controllers/User/ReferralController.php
+++ b/app/Http/Controllers/User/ReferralController.php
@@ -5,14 +5,14 @@ namespace App\Http\Controllers\User;
 use App\Actions\SendCurrency;
 use App\Enums\CurrencyTypes;
 use App\Http\Controllers\Controller;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Auth;
 
 class ReferralController extends Controller
 {
     public function __invoke(SendCurrency $sendCurrency): RedirectResponse
     {
-        $user = Auth::user();
+        $user = AuthenticatedUser::current();
         $referralsNeeded = (int) setting('referrals_needed', 5);
 
         if (! $user->referrals || $user->referrals->referrals_total < $referralsNeeded) {

--- a/app/Http/Controllers/User/TwoFactorAuthenticationController.php
+++ b/app/Http/Controllers/User/TwoFactorAuthenticationController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
+use App\Support\AuthenticatedUser;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
@@ -18,14 +19,14 @@ class TwoFactorAuthenticationController extends Controller
 
     public function store(Request $request, EnableTwoFactorAuthentication $enable): RedirectResponse
     {
-        $enable($request->user());
+        $enable(AuthenticatedUser::from($request));
 
         return redirect()->route('settings.two-factor')->with('success', __('Two-factor authentication has been enabled. Please scan the QR code to continue.'));
     }
 
     public function verify(Request $request): RedirectResponse
     {
-        $confirmed = $request->user()->confirmTwoFactorAuthentication($request->input('code'));
+        $confirmed = AuthenticatedUser::from($request)->confirmTwoFactorAuthentication($request->string('code')->toString());
         if (! $confirmed) {
             return back()->withErrors('Invalid Two Factor Authentication code');
         }
@@ -35,7 +36,7 @@ class TwoFactorAuthenticationController extends Controller
 
     public function destroy(Request $request, DisableTwoFactorAuthentication $disable): RedirectResponse
     {
-        $disable($request->user());
+        $disable(AuthenticatedUser::from($request));
 
         return redirect()->route('settings.two-factor')->with('success', __('Two-factor authentication has been disabled.'));
     }

--- a/app/Http/Middleware/BannedMiddleware.php
+++ b/app/Http/Middleware/BannedMiddleware.php
@@ -3,9 +3,9 @@
 namespace App\Http\Middleware;
 
 use App\Emulator\Contracts\BanRepository;
+use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class BannedMiddleware
@@ -21,7 +21,9 @@ class BannedMiddleware
         $ipBan = $this->bans->activeIpBan((string) $request->ip()) !== null;
         $onBannedPage = $request->is('banned');
 
-        if (! Auth::check()) {
+        $user = $request->user();
+
+        if (! $user instanceof User) {
             if ($ipBan && ! $onBannedPage) {
                 return to_route('banned.show');
             }
@@ -29,7 +31,7 @@ class BannedMiddleware
             return $onBannedPage && ! $ipBan ? to_route('login') : $next($request);
         }
 
-        $accountBan = $this->bans->activeAccountBan($request->user()) !== null;
+        $accountBan = $this->bans->activeAccountBan($user) !== null;
 
         if (($ipBan || $accountBan) && ! $onBannedPage) {
             return to_route('banned.show');

--- a/app/Http/Middleware/ForceStaffTwoFactorMiddleware.php
+++ b/app/Http/Middleware/ForceStaffTwoFactorMiddleware.php
@@ -2,20 +2,21 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 class ForceStaffTwoFactorMiddleware
 {
     public function handle(Request $request, Closure $next): Response
     {
-        if (! Auth::check() || ! setting('force_staff_2fa')) {
+        $user = $request->user();
+
+        if (! $user instanceof User || ! setting('force_staff_2fa')) {
             return $next($request);
         }
 
-        $user = $request->user();
         $urls = [
             'user/settings/two-factor',
             'user/settings/2fa-verify',

--- a/app/Http/Middleware/MaintenanceMiddleware.php
+++ b/app/Http/Middleware/MaintenanceMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -44,7 +45,10 @@ class MaintenanceMiddleware
     {
         // Default to rank 5 when unset; a missing setting must not let every
         // logged-in user through ("rank >= null" is always true).
-        return Auth::check() && Auth::user()->rank >= (int) (setting('min_maintenance_login_rank') ?: 5);
+        $user = Auth::user();
+
+        return $user instanceof User
+            && $user->rank >= (int) (setting('min_maintenance_login_rank') ?: 5);
     }
 
     private function isTwoFactorRoute(Request $request): bool

--- a/app/Http/Middleware/VPNCheckerMiddleware.php
+++ b/app/Http/Middleware/VPNCheckerMiddleware.php
@@ -37,7 +37,13 @@ class VPNCheckerMiddleware
     private function checkReputation(Request $request, Closure $next): Response
     {
         $ip = $request->ip();
-        $apiResponse = (new IpLookupService(setting('ipdata_api_key')))->ipLookup($ip);
+        $apiKey = setting('ipdata_api_key');
+
+        if (! is_string($ip) || ! is_string($apiKey) || $apiKey === '') {
+            return $next($request);
+        }
+
+        $apiResponse = (new IpLookupService($apiKey))->ipLookup($ip);
         $asn = $apiResponse['asn']['asn'] ?? '';
 
         if ($this->asnListed($asn, WebsiteIpWhitelist::class, 'whitelist_asn')) {

--- a/app/Http/Requests/AccountSettingsFormRequest.php
+++ b/app/Http/Requests/AccountSettingsFormRequest.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Requests;
 
+use App\Models\User;
 use App\Rules\CurrentPasswordRule;
 use App\Rules\GoogleRecaptchaRule;
 use App\Rules\WebsiteWordfilterRule;
+use App\Support\AuthenticatedUser;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
@@ -14,25 +16,26 @@ class AccountSettingsFormRequest extends FormRequest
     /** @return array<string, mixed> */
     public function rules(): array
     {
+        $user = AuthenticatedUser::from($this);
         $rules = [
-            'username' => ['sometimes', 'string', sprintf('regex:%s', setting('username_regex')), 'min:3', 'max:25', Rule::unique('users')->ignore($this->user()->id), new WebsiteWordfilterRule],
-            'mail' => ['required', 'email', Rule::unique('users')->ignore($this->user()->id), new WebsiteWordfilterRule],
+            'username' => ['sometimes', 'string', sprintf('regex:%s', setting('username_regex')), 'min:3', 'max:25', Rule::unique('users')->ignore($user->id), new WebsiteWordfilterRule],
+            'mail' => ['required', 'email', Rule::unique('users')->ignore($user->id), new WebsiteWordfilterRule],
             'motto' => ['nullable', 'string', 'max:127', new WebsiteWordfilterRule],
             'g-recaptcha-response' => [new GoogleRecaptchaRule],
             'cf-turnstile-response' => [app(Turnstile::class)],
         ];
 
         // Re-authenticate before a security-sensitive email change.
-        if ($this->emailIsChanging()) {
+        if ($this->emailIsChanging($user)) {
             $rules['current_password'] = ['required', 'string', new CurrentPasswordRule];
         }
 
         return $rules;
     }
 
-    private function emailIsChanging(): bool
+    private function emailIsChanging(User $user): bool
     {
-        return $this->user()->mail !== $this->input('mail');
+        return $user->mail !== $this->input('mail');
     }
 
     public function authorize(): bool

--- a/app/Models/Compositions/HasHome.php
+++ b/app/Models/Compositions/HasHome.php
@@ -111,10 +111,15 @@ trait HasHome
 
     public function loadRatingsForHome(): self
     {
-        $this->homeRatingStats = $this->homeRatings()
+        $stats = $this->homeRatings()
             ->selectRaw('AVG(rating) as rating_avg, COUNT(*) as total, COUNT(IF(rating >= 4, 4, NULL)) as most_positive')
             ->first();
 
+        $this->homeRatingStats = $stats ?? new UserHomeRating([
+            'rating_avg' => 0,
+            'total' => 0,
+            'most_positive' => 0,
+        ]);
         $this->homeRatingStats->rating_avg = number_format((float) ($this->homeRatingStats->rating_avg ?? 0), 1);
 
         return $this;

--- a/app/Models/Home/UserHomeItem.php
+++ b/app/Models/Home/UserHomeItem.php
@@ -72,19 +72,20 @@ class UserHomeItem extends Model
     public function setWidgetContent(User $user): void
     {
         $this->content = null;
+        $homeItem = $this->homeItem;
 
-        if ($this->homeItem->type !== HomeItemType::Widget) {
+        if ($homeItem === null || $homeItem->type !== HomeItemType::Widget) {
             return;
         }
 
-        $allAvailableWidgets = $this->homeItem->getAvailableWidgets();
+        $allAvailableWidgets = $homeItem->getAvailableWidgets();
 
-        if (empty($allAvailableWidgets) || ! array_key_exists($this->homeItem->name, $allAvailableWidgets)) {
+        if (empty($allAvailableWidgets) || ! array_key_exists($homeItem->name, $allAvailableWidgets)) {
             return;
         }
 
-        $this->widget_type = $allAvailableWidgets[$this->homeItem->name];
+        $this->widget_type = $allAvailableWidgets[$homeItem->name];
         $this->content = app(HomeService::class)->getWidgetContent($user, $this);
-        $this->homeItem->name = __($this->homeItem->name);
+        $homeItem->name = __($homeItem->name);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -30,6 +30,7 @@ use Database\Factories\UserFactory;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasName;
 use Filament\Panel;
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -424,8 +425,17 @@ class User extends Authenticatable implements FilamentUser, HasName
 
     public function confirmTwoFactorAuthentication(string $code): bool
     {
-        $codeIsValid = app(TwoFactorAuthenticationProvider::class)
-            ->verify(decrypt($this->two_factor_secret), $code);
+        if ($this->two_factor_secret === null) {
+            return false;
+        }
+
+        try {
+            $secret = decrypt($this->two_factor_secret);
+        } catch (DecryptException) {
+            return false;
+        }
+
+        $codeIsValid = app(TwoFactorAuthenticationProvider::class)->verify($secret, $code);
 
         if (! $codeIsValid) {
             return false;

--- a/app/Models/WebsiteAd.php
+++ b/app/Models/WebsiteAd.php
@@ -42,7 +42,7 @@ class WebsiteAd extends Model
         $settingsService = app(SettingsService::class);
 
         $adsPicturePath = Cache::remember('ads_picture_path', 3600, function () use ($settingsService) {
-            return $settingsService->getOrDefault('ads_picture_path');
+            return $settingsService->getOrDefault('ads_picture_path', '');
         });
 
         if (! str_starts_with($adsPicturePath, 'http')) {

--- a/app/Rules/CurrentPasswordRule.php
+++ b/app/Rules/CurrentPasswordRule.php
@@ -2,6 +2,7 @@
 
 namespace App\Rules;
 
+use App\Models\User;
 use Closure;
 use Illuminate\Contracts\Validation\InvokableRule;
 use Illuminate\Support\Facades\Auth;
@@ -14,7 +15,9 @@ class CurrentPasswordRule implements InvokableRule
      */
     public function __invoke(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! Hash::check($value, Auth::user()->password)) {
+        $user = Auth::user();
+
+        if (! $user instanceof User || ! is_string($value) || ! Hash::check($value, $user->password)) {
             $fail('It seems like your current password is wrong.');
         }
     }

--- a/app/Rules/ValidGifBadge.php
+++ b/app/Rules/ValidGifBadge.php
@@ -42,6 +42,11 @@ class ValidGifBadge implements ValidationRule
     public static function decode(string $value): ?string
     {
         $stripped = preg_replace('#^data:image/\w+;base64,#i', '', $value);
+
+        if ($stripped === null) {
+            return null;
+        }
+
         $decoded = base64_decode($stripped, true);
 
         return $decoded === false ? null : $decoded;

--- a/app/Rules/ValidateInstallationKeyRule.php
+++ b/app/Rules/ValidateInstallationKeyRule.php
@@ -10,7 +10,11 @@ class ValidateInstallationKeyRule implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if ($value !== WebsiteInstallation::first()->installation_key) {
+        $installationKey = WebsiteInstallation::query()->oldest('id')->value('installation_key');
+
+        if (! is_string($value)
+            || ! is_string($installationKey)
+            || ! hash_equals($installationKey, $value)) {
             $fail('The :attribute does not match');
         }
     }

--- a/app/Services/Home/HomeService.php
+++ b/app/Services/Home/HomeService.php
@@ -105,19 +105,24 @@ class HomeService
         DB::transaction(function () use ($itemsCollection, $allItems): void {
             $allItems->each(function (UserHomeItem $item) use ($itemsCollection): void {
                 $itemData = $itemsCollection->where('id', $item->id)->first();
+                $homeItem = $item->homeItem;
+
+                if ($homeItem === null) {
+                    return;
+                }
 
                 $item->placed = (bool) ($itemData['placed'] ?? $item->placed);
                 $item->x = (int) ($itemData['x'] ?? $item->x);
                 $item->y = (int) ($itemData['y'] ?? $item->y);
                 $item->z = (int) ($itemData['z'] ?? $item->z);
                 $item->is_reversed = (bool) ($itemData['is_reversed'] ?? $item->is_reversed);
-                $item->theme = $itemData['theme'] ?? $item->homeItem->getDefaultTheme();
+                $item->theme = $itemData['theme'] ?? $homeItem->getDefaultTheme();
 
                 if (! empty($itemData['extra_data'])) {
                     $item->extra_data = strip_tags($itemData['extra_data']);
                 }
 
-                if (! $item->placed && $item->homeItem->type === HomeItemType::Note) {
+                if (! $item->placed && $homeItem->type === HomeItemType::Note) {
                     $item->extra_data = '';
                 }
 

--- a/app/Services/HousekeepingPermissionsService.php
+++ b/app/Services/HousekeepingPermissionsService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Models\User;
 use App\Models\WebsiteHousekeepingPermission;
 use Illuminate\Support\Collection;
 
@@ -21,6 +22,9 @@ class HousekeepingPermissionsService
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $this->permissions->get($permissionName);
+        $user = auth()->user();
+
+        return $user instanceof User
+            && $user->rank >= (int) $this->permissions->get($permissionName);
     }
 }

--- a/app/Services/PermissionsService.php
+++ b/app/Services/PermissionsService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Models\Miscellaneous\WebsitePermission;
+use App\Models\User;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -26,6 +27,9 @@ class PermissionsService
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $this->permissions->get($permissionName);
+        $user = auth()->user();
+
+        return $user instanceof User
+            && $user->rank >= (int) $this->permissions->get($permissionName);
     }
 }

--- a/app/Services/RconService.php
+++ b/app/Services/RconService.php
@@ -71,7 +71,7 @@ class RconService implements Rcon
 
     public function sendCommand(string $command, ?array $data = null): bool
     {
-        if (! $this->isConnected) {
+        if (! $this->isConnected || ! $this->socket instanceof Socket) {
             Log::error('RCON command failed: Not connected');
 
             $this->closeConnection();
@@ -80,9 +80,10 @@ class RconService implements Rcon
         }
 
         $payload = json_encode(['key' => $command, 'data' => $data], JSON_THROW_ON_ERROR);
+        $socket = $this->socket;
 
-        if (! @socket_write($this->socket, $payload, strlen($payload))) {
-            Log::error("RCON command ($command) failed: " . socket_strerror(socket_last_error($this->socket)));
+        if (! @socket_write($socket, $payload, strlen($payload))) {
+            Log::error("RCON command ($command) failed: " . socket_strerror(socket_last_error($socket)));
 
             $this->closeConnection();
 

--- a/app/Services/User/SessionService.php
+++ b/app/Services/User/SessionService.php
@@ -4,10 +4,10 @@ namespace App\Services\User;
 
 use App\Data\SessionLogData;
 use App\Models\Session;
+use App\Support\AuthenticatedUser;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Auth;
 use Jenssegers\Agent\Agent;
 
 class SessionService
@@ -18,7 +18,7 @@ class SessionService
     public function fetchSessionLogs(Request $request): Collection
     {
         return collect(
-            Auth::user()->sessions,
+            AuthenticatedUser::from($request)->sessions,
         )->map(function ($session) use ($request) {
             $agent = $this->createAgent($session);
 

--- a/app/Support/AuthenticatedUser.php
+++ b/app/Support/AuthenticatedUser.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\User;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+final class AuthenticatedUser
+{
+    /** @throws AuthenticationException */
+    public static function from(Request $request): User
+    {
+        $user = $request->user();
+
+        if (! $user instanceof User) {
+            throw new AuthenticationException;
+        }
+
+        return $user;
+    }
+
+    /** @throws AuthenticationException */
+    public static function current(): User
+    {
+        $user = Auth::user();
+
+        if (! $user instanceof User) {
+            throw new AuthenticationException;
+        }
+
+        return $user;
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
     paths:
         - app/
 
-    level: 7
+    level: 8
 
     treatPhpDocTypesAsCertain: false
 


### PR DESCRIPTION
## Summary
- raise Larastan from level 7 to level 8 with no new suppressions
- replace nullable authentication access with a typed request boundary
- handle missing relations, installation state, malformed 2FA secrets, and invalid runtime configuration explicitly
- retain validated registration data and guard malformed domain records

## Audit result
Resolved all 91 findings reported by level 8. The pass covered controllers, middleware, Filament resources, models, rules, console commands, and services.

## Verification
- `vendor/bin/pint --test` on every changed PHP file
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pest` - 141 tests, 400 assertions