### PR TITLE
fix: isolate and invalidate community caches

### DIFF
--- a/app/Http/Controllers/Community/Staff/StaffController.php
+++ b/app/Http/Controllers/Community/Staff/StaffController.php
@@ -4,15 +4,16 @@ namespace App\Http\Controllers\Community\Staff;
 
 use App\Http\Controllers\Controller;
 use App\Services\Community\StaffService;
+use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class StaffController extends Controller
 {
     public function __construct(private readonly StaffService $staffService) {}
 
-    public function __invoke(): View
+    public function __invoke(Request $request): View
     {
-        $employees = $this->staffService->fetchStaffPositions();
+        $employees = $this->staffService->fetchStaffPositions($request->user());
 
         return view('community.staff', [
             'employees' => $employees,

--- a/app/Models/Miscellaneous/WebsiteSetting.php
+++ b/app/Models/Miscellaneous/WebsiteSetting.php
@@ -3,6 +3,7 @@
 namespace App\Models\Miscellaneous;
 
 use App\Services\SettingsService;
+use App\Support\CommunityCache;
 use Illuminate\Database\Eloquent\Model;
 
 /**
@@ -29,7 +30,13 @@ class WebsiteSetting extends Model
 
     protected static function booted(): void
     {
-        static::saved(fn () => SettingsService::clearCache());
-        static::deleted(fn () => SettingsService::clearCache());
+        static::saved(function (): void {
+            SettingsService::clearCache();
+            CommunityCache::forgetAll();
+        });
+        static::deleted(function (): void {
+            SettingsService::clearCache();
+            CommunityCache::forgetAll();
+        });
     }
 }

--- a/app/Observers/CommunityCacheObserver.php
+++ b/app/Observers/CommunityCacheObserver.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Community\Staff\WebsiteTeam as StaffWebsiteTeam;
+use App\Models\Community\Teams\WebsiteTeam;
+use App\Models\Game\Permission;
+use App\Models\User;
+use App\Support\CommunityCache;
+use Illuminate\Database\Eloquent\Model;
+
+class CommunityCacheObserver
+{
+    private const STAFF_PRESENTATION_ATTRIBUTES = [
+        'hidden_staff',
+        'look',
+        'motto',
+        'online',
+        'rank',
+        'username',
+    ];
+
+    private const TEAM_PRESENTATION_ATTRIBUTES = [
+        'look',
+        'motto',
+        'online',
+        'rank',
+        'team_id',
+        'username',
+    ];
+
+    public function created(Model $model): void
+    {
+        $this->forgetAffectedCaches($model, createdOrDeleted: true);
+    }
+
+    public function updated(Model $model): void
+    {
+        $this->forgetAffectedCaches($model, createdOrDeleted: false);
+    }
+
+    public function deleted(Model $model): void
+    {
+        $this->forgetAffectedCaches($model, createdOrDeleted: true);
+    }
+
+    private function forgetAffectedCaches(Model $model, bool $createdOrDeleted): void
+    {
+        if ($model instanceof User) {
+            $isStaff = $model->rank >= (int) setting('min_staff_rank', 5);
+
+            if (($createdOrDeleted && $isStaff) || (! $createdOrDeleted && $model->wasChanged(self::STAFF_PRESENTATION_ATTRIBUTES))) {
+                CommunityCache::forgetStaffPositions();
+            }
+
+            if (($createdOrDeleted && $isStaff) || (! $createdOrDeleted && $model->wasChanged('rank'))) {
+                CommunityCache::forgetStaffIds();
+            }
+
+            if (($createdOrDeleted && $model->team_id !== null) || (! $createdOrDeleted && $model->wasChanged(self::TEAM_PRESENTATION_ATTRIBUTES))) {
+                CommunityCache::forgetTeams();
+            }
+
+            return;
+        }
+
+        if ($model instanceof Permission) {
+            CommunityCache::forgetStaffPositions();
+            CommunityCache::forgetTeams();
+
+            return;
+        }
+
+        if ($model instanceof StaffWebsiteTeam || $model instanceof WebsiteTeam) {
+            CommunityCache::forgetTeams();
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,11 @@
 
 namespace App\Providers;
 
+use App\Models\Community\Staff\WebsiteTeam as StaffWebsiteTeam;
+use App\Models\Community\Teams\WebsiteTeam;
+use App\Models\Game\Permission;
 use App\Models\User;
+use App\Observers\CommunityCacheObserver;
 use App\Observers\UserObserver;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
@@ -23,7 +27,10 @@ class EventServiceProvider extends ServiceProvider
     ];
 
     protected $observers = [
-        User::class => [UserObserver::class],
+        User::class => [UserObserver::class, CommunityCacheObserver::class],
+        Permission::class => [CommunityCacheObserver::class],
+        StaffWebsiteTeam::class => [CommunityCacheObserver::class],
+        WebsiteTeam::class => [CommunityCacheObserver::class],
     ];
 
     /**

--- a/app/Services/Community/StaffService.php
+++ b/app/Services/Community/StaffService.php
@@ -4,62 +4,59 @@ namespace App\Services\Community;
 
 use App\Models\Game\Permission;
 use App\Models\User;
+use App\Support\CommunityCache;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 
 class StaffService
 {
-    public function fetchStaffPositions(): Collection
+    /**
+     * @return Collection<int, Permission>
+     */
+    public function fetchStaffPositions(User $viewer): Collection
     {
         $cacheEnabled = setting('enable_caching') === '1';
-
-        if ($cacheEnabled && Cache::has('staff_positions')) {
-            return Cache::get('staff_positions');
-        }
-
-        $employees = Permission::query()
+        $includeHidden = $viewer->rank >= (int) setting('min_rank_to_see_hidden_staff');
+        $resolve = fn (): Collection => Permission::query()
             ->select('id', 'rank_name', 'badge', 'staff_color', 'job_description')
-            ->when(Auth::user()->rank < (int) setting('min_rank_to_see_hidden_staff'), function ($query) {
-                return $query->where('hidden_rank', false);
-            })
+            ->when(! $includeHidden, fn ($query) => $query->where('hidden_rank', false))
             ->where('id', '>=', setting('min_staff_rank'))
             ->orderByDesc('id')
-            ->with(['users' => function ($query) {
+            ->with(['users' => function ($query) use ($includeHidden) {
                 $query->select('id', 'username', 'rank', 'motto', 'look', 'hidden_staff', 'online')
-                    ->when(Auth::user()->rank < (int) setting('min_rank_to_see_hidden_staff'), function ($query) {
-                        return $query->where('hidden_staff', false);
-                    })
+                    ->when(! $includeHidden, fn ($query) => $query->where('hidden_staff', false))
                     ->with('permission:id,rank_name,staff_background');
             }])
             ->get();
 
-        if ($cacheEnabled) {
-            $cacheTimer = (int) setting('cache_timer');
-            Cache::put('staff_positions', $employees, now()->addMinutes($cacheTimer));
+        if (! $cacheEnabled) {
+            return $resolve();
         }
 
-        return $employees;
+        return Cache::remember(
+            CommunityCache::staffPositionsKey($includeHidden),
+            now()->addMinutes((int) setting('cache_timer')),
+            $resolve,
+        );
     }
 
     public function fetchEmployeeIds(): array
     {
         $cacheEnabled = setting('enable_caching') === '1';
 
-        if ($cacheEnabled && Cache::has('staff_ids')) {
-            return Cache::get('staff_ids');
-        }
-
-        $staffIds = User::select('id')
+        $resolve = fn (): array => User::select('id')
             ->where('rank', '>=', setting('min_staff_rank'))
             ->get()
             ->pluck('id')->toArray();
 
-        if ($cacheEnabled) {
-            $cacheTimer = (int) setting('cache_timer');
-            Cache::put('staff_ids', $staffIds, now()->addMinutes($cacheTimer));
+        if (! $cacheEnabled) {
+            return $resolve();
         }
 
-        return $staffIds;
+        return Cache::remember(
+            CommunityCache::STAFF_IDS,
+            now()->addMinutes((int) setting('cache_timer')),
+            $resolve,
+        );
     }
 }

--- a/app/Services/Community/TeamService.php
+++ b/app/Services/Community/TeamService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Community;
 
 use App\Models\Community\Teams\WebsiteTeam;
+use App\Support\CommunityCache;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -12,11 +13,7 @@ class TeamService
     {
         $cacheEnabled = setting('enable_caching') === '1';
 
-        if ($cacheEnabled && Cache::has('hotel_teams')) {
-            return Cache::get('hotel_teams');
-        }
-
-        $employees = WebsiteTeam::select([
+        $resolve = fn (): Collection => WebsiteTeam::select([
             'id',
             'rank_name',
             'badge',
@@ -32,11 +29,14 @@ class TeamService
             }])
             ->get();
 
-        if ($cacheEnabled) {
-            $cacheTimer = (int) setting('cache_timer');
-            Cache::put('hotel_teams', $employees, now()->addMinutes($cacheTimer));
+        if (! $cacheEnabled) {
+            return $resolve();
         }
 
-        return $employees;
+        return Cache::remember(
+            CommunityCache::TEAMS,
+            now()->addMinutes((int) setting('cache_timer')),
+            $resolve,
+        );
     }
 }

--- a/app/Support/CommunityCache.php
+++ b/app/Support/CommunityCache.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+final class CommunityCache
+{
+    public const STAFF_IDS = 'community.staff.ids';
+
+    public const STAFF_POSITIONS_PRIVILEGED = 'community.staff.positions.privileged';
+
+    public const STAFF_POSITIONS_PUBLIC = 'community.staff.positions.public';
+
+    public const TEAMS = 'community.teams';
+
+    public static function staffPositionsKey(bool $includeHidden): string
+    {
+        return $includeHidden
+            ? self::STAFF_POSITIONS_PRIVILEGED
+            : self::STAFF_POSITIONS_PUBLIC;
+    }
+
+    public static function forgetStaffPositions(): void
+    {
+        Cache::forget(self::STAFF_POSITIONS_PRIVILEGED);
+        Cache::forget(self::STAFF_POSITIONS_PUBLIC);
+    }
+
+    public static function forgetStaffIds(): void
+    {
+        Cache::forget(self::STAFF_IDS);
+    }
+
+    public static function forgetTeams(): void
+    {
+        Cache::forget(self::TEAMS);
+    }
+
+    public static function forgetAll(): void
+    {
+        self::forgetStaffPositions();
+        self::forgetStaffIds();
+        self::forgetTeams();
+    }
+}

--- a/tests/Feature/Community/CommunityCacheTest.php
+++ b/tests/Feature/Community/CommunityCacheTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\Community\Staff\WebsiteTeam;
+use App\Models\Game\Permission;
+use App\Models\User;
+use App\Services\Community\StaffService;
+use App\Services\Community\TeamService;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    installHotel();
+    setSetting('enable_caching', '1');
+    setSetting('cache_timer', '60');
+    setSetting('min_staff_rank', '5');
+    setSetting('min_rank_to_see_hidden_staff', '7');
+    Cache::flush();
+});
+
+test('a privileged staff cache cannot expose hidden staff to regular users', function () {
+    Permission::whereKey(5)->update(['hidden_rank' => false]);
+    Permission::whereKey(6)->update(['hidden_rank' => true]);
+
+    User::factory()->create([
+        'username' => 'VisibleStaff',
+        'rank' => 5,
+        'hidden_staff' => false,
+    ]);
+    User::factory()->create([
+        'username' => 'HiddenStaff',
+        'rank' => 5,
+        'hidden_staff' => true,
+    ]);
+    User::factory()->create([
+        'username' => 'HiddenRankStaff',
+        'rank' => 6,
+        'hidden_staff' => false,
+    ]);
+
+    $privilegedViewer = User::factory()->create(['rank' => 7]);
+    $regularViewer = User::factory()->create(['rank' => 1]);
+    $service = app(StaffService::class);
+
+    $privilegedNames = $service->fetchStaffPositions($privilegedViewer)
+        ->flatMap->users
+        ->pluck('username');
+    $publicNames = $service->fetchStaffPositions($regularViewer)
+        ->flatMap->users
+        ->pluck('username');
+
+    expect($privilegedNames)
+        ->toContain('HiddenStaff', 'HiddenRankStaff')
+        ->and($publicNames)
+        ->toContain('VisibleStaff')
+        ->not->toContain('HiddenStaff', 'HiddenRankStaff');
+});
+
+test('staff caches are invalidated when displayed users and permissions change', function () {
+    $viewer = User::factory()->create(['rank' => 1]);
+    $staff = User::factory()->create([
+        'username' => 'CacheStaff',
+        'rank' => 5,
+        'motto' => 'Before',
+    ]);
+    $service = app(StaffService::class);
+
+    expect($service->fetchStaffPositions($viewer)->flatMap->users->firstWhere('id', $staff->id)->motto)
+        ->toBe('Before');
+
+    $staff->update(['motto' => 'After']);
+
+    expect($service->fetchStaffPositions($viewer)->flatMap->users->firstWhere('id', $staff->id)->motto)
+        ->toBe('After')
+        ->and($service->fetchEmployeeIds())
+        ->toContain($staff->id);
+
+    $staff->update(['rank' => 1]);
+
+    expect($service->fetchEmployeeIds())->not->toContain($staff->id);
+
+    Permission::findOrFail(5)->update(['rank_name' => 'Cache Updated Rank']);
+    $staff->update(['rank' => 5]);
+
+    expect($service->fetchStaffPositions($viewer)->firstWhere('id', 5)->rank_name)
+        ->toBe('Cache Updated Rank');
+});
+
+test('staff visibility setting changes invalidate cached results', function () {
+    $viewer = User::factory()->create(['rank' => 1]);
+    $staff = User::factory()->create(['rank' => 5]);
+    $service = app(StaffService::class);
+
+    expect($service->fetchStaffPositions($viewer)->flatMap->users->pluck('id'))
+        ->toContain($staff->id);
+
+    setSetting('min_staff_rank', '6');
+
+    expect($service->fetchStaffPositions($viewer)->flatMap->users->pluck('id'))
+        ->not->toContain($staff->id);
+});
+
+test('team caches are invalidated when teams or their members change', function () {
+    $team = WebsiteTeam::create([
+        'rank_name' => 'Event Team',
+        'badge' => 'EVT',
+        'hidden_rank' => false,
+        'staff_color' => '#ffffff',
+        'staff_background' => '',
+        'job_description' => 'Runs events',
+    ]);
+    $member = User::factory()->create([
+        'username' => 'TeamMember',
+        'team_id' => $team->id,
+        'motto' => 'Before',
+    ]);
+    $service = app(TeamService::class);
+
+    expect($service->fetchTeams()->firstWhere('id', $team->id)->users->firstWhere('id', $member->id)->motto)
+        ->toBe('Before');
+
+    $member->update(['motto' => 'After']);
+
+    expect($service->fetchTeams()->firstWhere('id', $team->id)->users->firstWhere('id', $member->id)->motto)
+        ->toBe('After');
+
+    $team->update(['rank_name' => 'Updated Event Team']);
+
+    expect($service->fetchTeams()->firstWhere('id', $team->id)->rank_name)
+        ->toBe('Updated Event Team');
+});


### PR DESCRIPTION
## Summary
- separate public and privileged staff cache entries so hidden ranks and users cannot leak between viewers
- replace check-then-read cache access with atomic remember calls and centralized cache keys
- invalidate affected staff, leaderboard, and team caches when users, permissions, teams, or visibility settings change
- pass the authenticated viewer explicitly into staff visibility queries

## Verification
- `vendor/bin/pest` - 145 passed, 414 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint`
- `git diff --check`