### PR TITLE
fix: make user registration atomic

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -9,6 +9,7 @@ use App\Models\User;
 use App\Rules\BetaCodeRule;
 use App\Rules\GoogleRecaptchaRule;
 use App\Rules\WebsiteWordfilterRule;
+use App\Services\Auth\RegistrationMutex;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
@@ -21,6 +22,8 @@ class CreateNewUser implements CreatesNewUsers
 {
     use PasswordValidationRules;
 
+    public function __construct(private readonly RegistrationMutex $mutex) {}
+
     /**
      * Validate and create a newly registered user.
      *
@@ -30,13 +33,24 @@ class CreateNewUser implements CreatesNewUsers
     {
         $ip = request()->ip();
 
-        $this->ensureRegistrationAllowed($ip);
-        $this->validate($input);
+        $this->ensureRegistrationIsOpen($ip);
+        $validated = $this->validate($input);
+        $password = Hash::make($validated['password']);
 
-        $user = $this->createUser($input, $ip);
+        $user = $this->mutex->run(
+            $this->lockIdentifiers($validated, $ip),
+            function () use ($validated, $password, $ip): User {
+                $this->ensureRegistrationAllowed($ip);
+                $this->ensureIdentityIsAvailable($validated);
 
-        $this->applyBetaCode($input['beta_code'] ?? null, $user);
-        $this->recordReferral($input['referral_code'] ?? null, $user, $ip);
+                $user = $this->createUser($validated, $password, $ip);
+
+                $this->applyBetaCode($validated['beta_code'] ?? null, $user);
+                $this->recordReferral($validated['referral_code'] ?? null, $user, $ip);
+
+                return $user;
+            },
+        );
 
         if (setting('enable_discord_webhook') === '1') {
             // After the response, so registration never waits on Discord.
@@ -46,15 +60,20 @@ class CreateNewUser implements CreatesNewUsers
         return $user;
     }
 
-    private function ensureRegistrationAllowed(?string $ip): void
+    private function ensureRegistrationIsOpen(?string $ip): void
     {
-        if ((setting('disable_registration') ?: '0') == '1') {
+        if (setting('disable_registration', '0') === '1') {
             throw ValidationException::withMessages(['registration' => __('Registration is disabled.')]);
         }
-
         if (! filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)) {
             throw ValidationException::withMessages(['registration' => __('Your IP address seems to be invalid')]);
         }
+
+    }
+
+    private function ensureRegistrationAllowed(string $ip): void
+    {
+        $this->ensureRegistrationIsOpen($ip);
 
         $matchingIpCount = User::query()
             ->where('ip_current', $ip)
@@ -69,12 +88,12 @@ class CreateNewUser implements CreatesNewUsers
     /**
      * @param  array<string, mixed>  $input
      */
-    private function createUser(array $input, string $ip): User
+    private function createUser(array $input, string $password, string $ip): User
     {
         $user = User::create([
             'username' => $input['username'],
             'mail' => $input['mail'],
-            'password' => Hash::make($input['password']),
+            'password' => $password,
             'account_created' => time(),
             'last_login' => time(),
             'motto' => setting('start_motto') ?: 'Welcome to the hotel!',
@@ -93,11 +112,19 @@ class CreateNewUser implements CreatesNewUsers
 
     private function applyBetaCode(?string $betaCode, User $user): void
     {
-        if (! setting('requires_beta_code') || $betaCode === null) {
+        if (setting('requires_beta_code') !== '1' || $betaCode === null) {
             return;
         }
 
-        WebsiteBetaCode::where('code', $betaCode)->update(['user_id' => $user->id]);
+        $claimed = WebsiteBetaCode::where('code', $betaCode)
+            ->whereNull('user_id')
+            ->update(['user_id' => $user->id]);
+
+        if ($claimed !== 1) {
+            throw ValidationException::withMessages([
+                'beta_code' => __('The beta code is invalid.'),
+            ]);
+        }
     }
 
     /**
@@ -110,7 +137,9 @@ class CreateNewUser implements CreatesNewUsers
             return;
         }
 
-        $referralUser = User::where('referral_code', $referralCode)->first();
+        $referralUser = User::where('referral_code', $referralCode)
+            ->lockForUpdate()
+            ->first();
 
         if ($referralUser === null
             || $referralUser->ip_current === $user->ip_current
@@ -135,7 +164,8 @@ class CreateNewUser implements CreatesNewUsers
             'username' => ['required', 'string', sprintf('regex:%s', setting('username_regex') ?: '/^[a-zA-Z0-9_.-]+$/'), 'max:25', Rule::unique('users'), new WebsiteWordfilterRule],
             'mail' => ['required', 'string', 'email', 'max:255', Rule::unique('users')],
             'password' => $this->passwordRules(),
-            'beta_code' => ['sometimes', 'string', new BetaCodeRule],
+            'beta_code' => [Rule::requiredIf(setting('requires_beta_code') === '1'), 'nullable', 'string', new BetaCodeRule],
+            'referral_code' => ['nullable', 'string', 'max:255'],
             'terms' => ['required', 'accepted'],
             'g-recaptcha-response' => ['sometimes', 'string', new GoogleRecaptchaRule],
             'cf-turnstile-response' => [app(Turnstile::class)],
@@ -147,5 +177,37 @@ class CreateNewUser implements CreatesNewUsers
         ];
 
         return Validator::make($inputs, $rules, $messages)->validate();
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     *
+     * @return list<string>
+     */
+    private function lockIdentifiers(array $input, string $ip): array
+    {
+        return [
+            'ip:' . $ip,
+            'mail:' . Str::lower($input['mail']),
+            'username:' . Str::lower($input['username']),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private function ensureIdentityIsAvailable(array $input): void
+    {
+        if (User::where('username', $input['username'])->exists()) {
+            throw ValidationException::withMessages([
+                'username' => __('The username has already been taken.'),
+            ]);
+        }
+
+        if (User::where('mail', $input['mail'])->exists()) {
+            throw ValidationException::withMessages([
+                'mail' => __('The mail has already been taken.'),
+            ]);
+        }
     }
 }

--- a/app/Services/Auth/RegistrationMutex.php
+++ b/app/Services/Auth/RegistrationMutex.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+final class RegistrationMutex
+{
+    /**
+     * @template TResult
+     *
+     * @param  list<string>  $identifiers
+     * @param  Closure(): TResult  $callback
+     *
+     * @return TResult
+     */
+    public function run(array $identifiers, Closure $callback): mixed
+    {
+        $keys = collect($identifiers)
+            ->map(fn (string $identifier): string => hash('sha256', $identifier))
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        return DB::transaction(function () use ($keys, $callback): mixed {
+            foreach ($keys as $key) {
+                DB::table('website_registration_locks')->insertOrIgnore([
+                    'lock_key' => $key,
+                ]);
+            }
+
+            foreach ($keys as $key) {
+                DB::table('website_registration_locks')
+                    ->where('lock_key', $key)
+                    ->lockForUpdate()
+                    ->value('lock_key');
+            }
+
+            try {
+                return $callback();
+            } finally {
+                DB::table('website_registration_locks')
+                    ->whereIn('lock_key', $keys)
+                    ->delete();
+            }
+        }, attempts: 3);
+    }
+}

--- a/database/migrations/2026_07_16_030000_create_registration_locks_table.php
+++ b/database/migrations/2026_07_16_030000_create_registration_locks_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('website_registration_locks', function (Blueprint $table) {
+            $table->string('lock_key', 64)->primary();
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasIndex('users', ['ip_register'])) {
+                $table->index('ip_register', 'users_ip_register_registration_index');
+            }
+
+            if (! Schema::hasIndex('users', ['ip_current'])) {
+                $table->index('ip_current', 'users_ip_current_registration_index');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasIndex('users', 'users_ip_register_registration_index')) {
+                $table->dropIndex('users_ip_register_registration_index');
+            }
+
+            if (Schema::hasIndex('users', 'users_ip_current_registration_index')) {
+                $table->dropIndex('users_ip_current_registration_index');
+            }
+        });
+
+        Schema::dropIfExists('website_registration_locks');
+    }
+};

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,8 +1,10 @@
 <?php
 
 use App\Jobs\SendRegisteredUserWebhook;
+use App\Models\Miscellaneous\WebsiteBetaCode;
 use App\Models\User;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Testing\TestResponse;
 
 function register(array $overrides = []): TestResponse
@@ -60,4 +62,51 @@ test('the discord webhook is dispatched after the response', function () {
     register()->assertRedirect();
 
     Bus::assertDispatchedAfterResponse(SendRegisteredUserWebhook::class);
+});
+
+test('a required beta code cannot be omitted or reused', function () {
+    installHotel();
+    setSetting('requires_beta_code', '1');
+
+    register()->assertSessionHasErrors('beta_code');
+
+    $betaCode = WebsiteBetaCode::create(['code' => 'PRIVATE-BETA']);
+
+    register(['beta_code' => $betaCode->code])->assertRedirect();
+
+    expect($betaCode->fresh()->user_id)
+        ->toBe(User::where('username', 'Tester')->value('id'))
+        ->and(DB::table('website_registration_locks')->count())
+        ->toBe(0);
+
+    auth()->logout();
+
+    register([
+        'username' => 'SecondTester',
+        'mail' => 'second@example.com',
+        'beta_code' => $betaCode->code,
+    ])->assertSessionHasErrors('beta_code');
+
+    expect(User::where('username', 'SecondTester')->exists())->toBeFalse();
+});
+
+test('registration and observer side effects roll back together', function () {
+    installHotel();
+    $this->withoutExceptionHandling();
+
+    User::created(function (User $user): void {
+        if ($user->username === 'RollbackTester') {
+            throw new RuntimeException('Simulated initialization failure.');
+        }
+    });
+
+    expect(fn () => register([
+        'username' => 'RollbackTester',
+        'mail' => 'rollback@example.com',
+    ]))->toThrow(RuntimeException::class, 'Simulated initialization failure.');
+
+    expect(User::where('username', 'RollbackTester')->exists())
+        ->toBeFalse()
+        ->and(DB::table('website_registration_locks')->count())
+        ->toBe(0);
 });


### PR DESCRIPTION
## Summary
- serialize registrations that share an IP, username, or email through hashed database mutex keys
- create the user, observer-managed initialization, beta-code claim, and referral writes in one transaction
- recheck account limits and identity uniqueness while holding the registration locks
- make beta-code claims conditional and require a code when beta registration is enabled
- index registration IP fields used by the account-cap query

## Verification
- `vendor/bin/pest` - 143 passed, 412 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- migration apply, rollback, and reapply against MariaDB
- `vendor/bin/pint`
- `git diff --check`