### PR TITLE
fix: make referral claims atomic

### DIFF
--- a/app/Actions/User/ClaimReferralReward.php
+++ b/app/Actions/User/ClaimReferralReward.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions\User;
+
+use App\Actions\SendCurrency;
+use App\Enums\CurrencyTypes;
+use App\Models\User;
+use App\Models\User\UserReferral;
+use Illuminate\Support\Facades\DB;
+
+class ClaimReferralReward
+{
+    public function __construct(private readonly SendCurrency $sendCurrency) {}
+
+    public function execute(User $user, string $ipAddress): bool
+    {
+        $requiredReferrals = (int) setting('referrals_needed');
+        $rewardAmount = (int) setting('referral_reward_amount');
+
+        if ($requiredReferrals < 1 || $rewardAmount < 1) {
+            return false;
+        }
+
+        return DB::transaction(function () use ($user, $ipAddress, $requiredReferrals, $rewardAmount): bool {
+            $referrals = UserReferral::where('user_id', $user->id)
+                ->lockForUpdate()
+                ->first();
+
+            if ($referrals === null || $referrals->referrals_total < $requiredReferrals) {
+                return false;
+            }
+
+            $referrals->decrement('referrals_total', $requiredReferrals);
+            $this->sendCurrency->execute($user, CurrencyTypes::Diamonds, $rewardAmount);
+            $user->claimedReferralLog()->create([
+                'ip_address' => $ipAddress,
+            ]);
+
+            return true;
+        }, attempts: 3);
+    }
+}

--- a/app/Http/Controllers/User/ReferralController.php
+++ b/app/Http/Controllers/User/ReferralController.php
@@ -2,32 +2,25 @@
 
 namespace App\Http\Controllers\User;
 
-use App\Actions\SendCurrency;
-use App\Enums\CurrencyTypes;
+use App\Actions\User\ClaimReferralReward;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 class ReferralController extends Controller
 {
-    public function __invoke(SendCurrency $sendCurrency): RedirectResponse
+    public function __invoke(Request $request, ClaimReferralReward $claim): RedirectResponse
     {
-        $user = Auth::user();
-        if (! $user->referrals || $user->referrals->referrals_total < setting('referrals_needed')) {
+        $claimed = $claim->execute(
+            $request->user(),
+            $request->ip() ?: 'unknown',
+        );
+
+        if (! $claimed) {
             return redirect()->back()->withErrors([
                 'message' => __('You do not have enough referrals to claim your reward'),
             ]);
         }
-
-        // Decrease the total amount of referrals with the amount needed to claim reward
-        $user->referrals->decrement('referrals_total', setting('referrals_needed'));
-
-        $sendCurrency->execute($user, CurrencyTypes::Diamonds, (int) setting('referral_reward_amount'));
-
-        // Log the claim
-        $user->claimedReferralLog()->create([
-            'ip_address' => request()->ip(),
-        ]);
 
         return redirect()->back()->with('success', __('Woah! You have successfully claimed your reward - Keep up the good work!'));
     }

--- a/resources/themes/atom/views/user/me.blade.php
+++ b/resources/themes/atom/views/user/me.blade.php
@@ -73,11 +73,12 @@
                 </div>
 
                 @if (auth()->user()->referrals?->referrals_total >= (int) setting('referrals_needed'))
-                    <a href="{{ route('claim.referral-reward') }}" class="text-decoration-none">
+                    <form method="POST" action="{{ route('claim.referral-reward') }}">
+                        @csrf
                         <x-form.secondary-button classes="mt-2">
                             {{ __('Claim your referrals reward!') }}
                         </x-form.secondary-button>
-                    </a>
+                    </form>
                 @else
                     <button disabled class="mt-2 w-full rounded bg-gray-400 p-2 text-white dark:bg-gray-900">
                         {{ sprintf(__('You need to refer :needed more users, before being able to claim your reward', ['needed' =>auth()->user()->referralsNeeded() ?? 0]),auth()->user()->referrals->referrals_total ?? 0) }}

--- a/resources/themes/dusk/views/user/me.blade.php
+++ b/resources/themes/dusk/views/user/me.blade.php
@@ -166,11 +166,12 @@
                 </div>
 
                 @if (auth()->user()->referrals?->referrals_total >= (int) setting('referrals_needed'))
-                    <a href="{{ route('claim.referral-reward') }}" class="text-decoration-none">
+                    <form method="POST" action="{{ route('claim.referral-reward') }}">
+                        @csrf
                         <x-form.secondary-button classes="mt-2">
                             {{ __('Claim your referrals reward!') }}
                         </x-form.secondary-button>
-                    </a>
+                    </form>
                 @else
                     <button disabled class="mt-2 w-full rounded bg-[#171a23] p-2 text-white">
                         {{ sprintf(__('You need to refer :needed more users, before being able to claim your reward', ['needed' =>auth()->user()->referralsNeeded() ?? 0]),auth()->user()->referrals->referrals_total ?? 0) }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,7 +88,9 @@ Route::middleware(['maintenance', 'check.ban', 'force.staff.2fa'])->group(functi
     Route::middleware('auth')->group(function () {
         Route::prefix('user')->group(function () {
             Route::get('/me', MeController::class)->name('me.show');
-            Route::get('/claim/referral-reward', ReferralController::class)->name('claim.referral-reward');
+            Route::post('/claim/referral-reward', ReferralController::class)
+                ->middleware('throttle:5,1')
+                ->name('claim.referral-reward');
 
             // User settings routes
             Route::prefix('settings')->group(function () {

--- a/tests/Feature/User/ReferralClaimTest.php
+++ b/tests/Feature/User/ReferralClaimTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\SendCurrency;
 use App\Emulator\Contracts\CurrencyRepository;
 use App\Enums\CurrencyTypes;
 use App\Models\User;
@@ -16,11 +17,12 @@ test('a user with enough referrals claims the reward', function () {
     $user->referrals()->create(['referrals_total' => 4]);
 
     $this->actingAs($user)
-        ->get(route('claim.referral-reward'))
+        ->post(route('claim.referral-reward'))
         ->assertSessionHas('success');
 
     expect($user->referrals->fresh()->referrals_total)->toBe(1)
-        ->and(app(CurrencyRepository::class)->balance($user->fresh(), CurrencyTypes::Diamonds))->toBe(10);
+        ->and(app(CurrencyRepository::class)->balance($user->fresh(), CurrencyTypes::Diamonds))->toBe(10)
+        ->and($user->claimedReferralLog()->count())->toBe(1);
 });
 
 test('a user without enough referrals is rejected', function () {
@@ -28,8 +30,53 @@ test('a user without enough referrals is rejected', function () {
     $user->referrals()->create(['referrals_total' => 1]);
 
     $this->actingAs($user)
-        ->get(route('claim.referral-reward'))
+        ->post(route('claim.referral-reward'))
         ->assertSessionHasErrors();
 
     expect($user->referrals->fresh()->referrals_total)->toBe(1);
+});
+
+test('a referral reward cannot be replayed', function () {
+    $user = User::factory()->create();
+    $user->referrals()->create(['referrals_total' => 3]);
+
+    $this->actingAs($user)
+        ->post(route('claim.referral-reward'))
+        ->assertSessionHas('success');
+
+    $this->actingAs($user)
+        ->post(route('claim.referral-reward'))
+        ->assertSessionHasErrors();
+
+    expect($user->referrals->fresh()->referrals_total)->toBe(0)
+        ->and(app(CurrencyRepository::class)->balance($user->fresh(), CurrencyTypes::Diamonds))->toBe(10)
+        ->and($user->claimedReferralLog()->count())->toBe(1);
+});
+
+test('a failed reward grant rolls back the referral claim', function () {
+    $user = User::factory()->create();
+    $user->referrals()->create(['referrals_total' => 3]);
+
+    $currency = Mockery::mock(SendCurrency::class);
+    $currency->shouldReceive('execute')->once()->andThrow(new RuntimeException('Grant failed.'));
+    app()->instance(SendCurrency::class, $currency);
+    $this->withoutExceptionHandling();
+
+    expect(fn () => $this->actingAs($user)->post(route('claim.referral-reward')))
+        ->toThrow(RuntimeException::class, 'Grant failed.');
+
+    expect($user->referrals->fresh()->referrals_total)->toBe(3)
+        ->and($user->claimedReferralLog()->count())->toBe(0);
+});
+
+test('referral rewards cannot be claimed with a get request', function () {
+    $user = User::factory()->create();
+    $user->referrals()->create(['referrals_total' => 3]);
+
+    $this->actingAs($user)
+        ->get(route('claim.referral-reward'))
+        ->assertMethodNotAllowed();
+
+    expect($user->referrals->fresh()->referrals_total)->toBe(3)
+        ->and($user->claimedReferralLog()->count())->toBe(0);
 });


### PR DESCRIPTION
## Summary
- replace the state-changing referral claim GET with a CSRF-protected, throttled POST
- lock the user's referral counter before checking and consuming points
- keep point consumption, reward delivery, and claim logging in one retried transaction
- reject replayed claims and invalid reward configuration without granting currency
- update both Atom and Dusk themes to submit claim forms

## Verification
- `vendor/bin/pest` - 144 passed, 414 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint`
- Prettier check for both changed theme views
- `git diff --check`