### PR TITLE
fix: enforce staff application integrity

### DIFF
--- a/app/Actions/Community/SubmitStaffApplication.php
+++ b/app/Actions/Community/SubmitStaffApplication.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Actions\Community;
+
+use App\Models\Community\Staff\WebsiteStaffApplications;
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
+
+class SubmitStaffApplication
+{
+    public function forRank(User $user, int $rankId, string $content): WebsiteStaffApplications
+    {
+        return $this->submit($user, 'rank', $rankId, $content);
+    }
+
+    public function forTeam(User $user, int $teamId, string $content): WebsiteStaffApplications
+    {
+        return $this->submit($user, 'team', $teamId, $content);
+    }
+
+    private function submit(User $user, string $kind, int $targetId, string $content): WebsiteStaffApplications
+    {
+        $application = WebsiteStaffApplications::query()->createOrFirst(
+            ['application_key' => self::key($kind, $user->id, $targetId)],
+            [
+                'user_id' => $user->id,
+                'rank_id' => $kind === 'rank' ? $targetId : null,
+                'team_id' => $kind === 'team' ? $targetId : null,
+                'content' => $content,
+            ],
+        );
+
+        if (! $application->wasRecentlyCreated) {
+            throw ValidationException::withMessages([
+                'content' => $kind === 'rank'
+                    ? __('You have already applied for this position.')
+                    : __('You have already applied for this team.'),
+            ]);
+        }
+
+        return $application;
+    }
+
+    public static function key(string $kind, int $userId, int $targetId): string
+    {
+        return "{$kind}:{$userId}:{$targetId}";
+    }
+}

--- a/app/Http/Controllers/Community/Staff/StaffApplicationsController.php
+++ b/app/Http/Controllers/Community/Staff/StaffApplicationsController.php
@@ -2,10 +2,11 @@
 
 namespace App\Http\Controllers\Community\Staff;
 
+use App\Actions\Community\SubmitStaffApplication;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StaffApplicationFormRequest;
 use App\Models\Community\Staff\WebsiteOpenPosition;
-use App\Models\Community\Staff\WebsiteStaffApplications;
-use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 
 class StaffApplicationsController extends Controller
@@ -15,6 +16,7 @@ class StaffApplicationsController extends Controller
         $positions = WebsiteOpenPosition::query()
             ->where('position_kind', 'rank')
             ->whereNotNull('permission_id')
+            ->canApply()
             ->with('permission')
             ->whereHas('permission')
             ->latest()
@@ -27,32 +29,30 @@ class StaffApplicationsController extends Controller
     {
         abort_unless($position->position_kind === 'rank', 404);
         $position->loadMissing('permission');
-        abort_unless($position->permission !== null, 404);
+        abort_unless($position->permission !== null && $position->isAcceptingApplications(), 404);
 
         return view('community.staff-apply', compact('position'));
     }
 
-    public function store(Request $request, WebsiteOpenPosition $position)
-    {
-        abort_unless($position->position_kind === 'rank', 404);
+    public function store(
+        StaffApplicationFormRequest $request,
+        WebsiteOpenPosition $position,
+        SubmitStaffApplication $applications,
+    ): RedirectResponse {
+        $position->loadMissing('permission');
+        abort_unless(
+            $position->position_kind === 'rank'
+            && $position->permission !== null
+            && $position->permission_id !== null
+            && $position->isAcceptingApplications(),
+            404,
+        );
 
-        $validated = $request->validate([
-            'content' => ['required', 'string', 'min:10'],
-        ]);
-
-        $user = $request->user();
-
-        if ($user->hasAppliedForPosition($position->permission_id)) {
-            return back()->withErrors([
-                'content' => __('You have already applied for this position.'),
-            ])->withInput();
-        }
-
-        WebsiteStaffApplications::create([
-            'user_id' => $user->id,
-            'rank_id' => $position->permission_id,
-            'content' => $validated['content'],
-        ]);
+        $applications->forRank(
+            $request->user(),
+            $position->permission_id,
+            $request->string('content')->toString(),
+        );
 
         return redirect()
             ->route('staff-applications.index')

--- a/app/Http/Controllers/Community/Staff/WebsiteTeamApplicationsController.php
+++ b/app/Http/Controllers/Community/Staff/WebsiteTeamApplicationsController.php
@@ -2,30 +2,36 @@
 
 namespace App\Http\Controllers\Community\Staff;
 
+use App\Actions\Community\SubmitStaffApplication;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StaffApplicationFormRequest;
 use App\Models\Community\Staff\WebsiteOpenPosition;
 use App\Models\Community\Staff\WebsiteStaffApplications;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
 class WebsiteTeamApplicationsController extends Controller
 {
-    public function index(): View
+    public function index(Request $request): View
     {
         $positions = WebsiteOpenPosition::query()
             ->where('position_kind', 'team')
             ->whereNotNull('team_id')
+            ->canApply()
             ->with('team')
             ->whereHas('team')
             ->latest()
             ->get();
 
         $userAppStatuses = [];
-        if (auth()->check()) {
+        $user = $request->user();
+
+        if ($user !== null) {
             $teamIds = $positions->pluck('team_id')->filter()->unique()->all();
 
             $userAppStatuses = WebsiteStaffApplications::query()
-                ->where('user_id', auth()->id())
+                ->where('user_id', $user->id)
                 ->whereIn('team_id', $teamIds)
                 ->pluck('status', 'team_id')
                 ->toArray();
@@ -42,33 +48,32 @@ class WebsiteTeamApplicationsController extends Controller
         abort_unless($position->position_kind === 'team', 404);
 
         $position->loadMissing('team');
+        abort_unless($position->team !== null && $position->isAcceptingApplications(), 404);
 
         return view('community.team-apply', [
             'position' => $position,
         ]);
     }
 
-    public function store(Request $request, WebsiteOpenPosition $position)
-    {
-        abort_unless($position->position_kind === 'team', 404);
+    public function store(
+        StaffApplicationFormRequest $request,
+        WebsiteOpenPosition $position,
+        SubmitStaffApplication $applications,
+    ): RedirectResponse {
+        $position->loadMissing('team');
+        abort_unless(
+            $position->position_kind === 'team'
+            && $position->team !== null
+            && $position->team_id !== null
+            && $position->isAcceptingApplications(),
+            404,
+        );
 
-        $request->validate([
-            'content' => ['required', 'string', 'min:10'],
-        ]);
-
-        $user = $request->user();
-
-        if ($user->hasAppliedForTeam($position->team_id)) {
-            return back()->withErrors([
-                'content' => __('You have already applied for this team.'),
-            ]);
-        }
-
-        WebsiteStaffApplications::create([
-            'user_id' => $user->id,
-            'team_id' => $position->team_id,
-            'content' => $request->string('content'),
-        ]);
+        $applications->forTeam(
+            $request->user(),
+            $position->team_id,
+            $request->string('content')->toString(),
+        );
 
         return redirect()
             ->route('team-applications.index')

--- a/app/Http/Requests/StaffApplicationFormRequest.php
+++ b/app/Http/Requests/StaffApplicationFormRequest.php
@@ -11,9 +11,14 @@ class StaffApplicationFormRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'content' => ['required', 'string'],
+            'content' => ['required', 'string', 'min:10', 'max:5000'],
             'g-recaptcha-response' => [new GoogleRecaptchaRule],
             'cf-turnstile-response' => [app(Turnstile::class)],
         ];
+    }
+
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
     }
 }

--- a/app/Models/Community/Staff/WebsiteOpenPosition.php
+++ b/app/Models/Community/Staff/WebsiteOpenPosition.php
@@ -94,4 +94,12 @@ class WebsiteOpenPosition extends Model
     {
         return $query->where('apply_from', '<=', now())->where('apply_to', '>', now());
     }
+
+    public function isAcceptingApplications(): bool
+    {
+        return $this->apply_from !== null
+            && $this->apply_to !== null
+            && $this->apply_from->isPast()
+            && $this->apply_to->isFuture();
+    }
 }

--- a/app/Models/Community/Staff/WebsiteOpenPosition.php
+++ b/app/Models/Community/Staff/WebsiteOpenPosition.php
@@ -4,6 +4,7 @@ namespace App\Models\Community\Staff;
 
 use App\Models\Community\Teams\WebsiteTeam;
 use App\Models\Game\Permission;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -90,16 +91,24 @@ class WebsiteOpenPosition extends Model
         return $this->hasMany(WebsiteStaffApplications::class, 'rank_id', 'permission_id');
     }
 
-    public function scopeCanApply($query)
+    public function scopeCanApply(Builder $query): Builder
     {
-        return $query->where('apply_from', '<=', now())->where('apply_to', '>', now());
+        $now = now();
+
+        return $query
+            ->where(fn (Builder $query): Builder => $query
+                ->whereNull('apply_from')
+                ->orWhere('apply_from', '<=', $now))
+            ->where(fn (Builder $query): Builder => $query
+                ->whereNull('apply_to')
+                ->orWhere('apply_to', '>', $now));
     }
 
     public function isAcceptingApplications(): bool
     {
-        return $this->apply_from !== null
-            && $this->apply_to !== null
-            && $this->apply_from->isPast()
-            && $this->apply_to->isFuture();
+        $now = now();
+
+        return ($this->apply_from === null || $this->apply_from->lessThanOrEqualTo($now))
+            && ($this->apply_to === null || $this->apply_to->greaterThan($now));
     }
 }

--- a/app/Models/Community/Staff/WebsiteStaffApplications.php
+++ b/app/Models/Community/Staff/WebsiteStaffApplications.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
+ * @property string|null $application_key
  * @property int $user_id
  * @property int|null $rank_id
  * @property int|null $team_id
@@ -52,6 +53,7 @@ class WebsiteStaffApplications extends Model
 
     protected $fillable = [
         'user_id',
+        'application_key',
         'rank_id',
         'team_id',
         'content',

--- a/database/migrations/2026_07_16_040000_add_staff_application_keys.php
+++ b/database/migrations/2026_07_16_040000_add_staff_application_keys.php
@@ -1,0 +1,62 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('website_staff_applications', function (Blueprint $table) {
+            $table->string('application_key')->nullable()->after('id');
+        });
+
+        $this->assignCanonicalKeys('rank', 'rank_id', 'team_id');
+        $this->assignCanonicalKeys('team', 'team_id', 'rank_id');
+
+        Schema::table('website_staff_applications', function (Blueprint $table) {
+            $table->unique('application_key', 'staff_applications_key_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('website_staff_applications', function (Blueprint $table) {
+            $table->dropUnique('staff_applications_key_unique');
+            $table->dropColumn('application_key');
+        });
+    }
+
+    private function assignCanonicalKeys(string $kind, string $targetColumn, string $otherTargetColumn): void
+    {
+        $seen = [];
+
+        DB::table('website_staff_applications')
+            ->select(['id', 'user_id', $targetColumn])
+            ->whereNotNull($targetColumn)
+            ->whereNull($otherTargetColumn)
+            ->orderBy('id')
+            ->chunkById(500, function ($applications) use ($kind, $targetColumn, &$seen): void {
+                foreach ($applications as $application) {
+                    $key = sprintf(
+                        '%s:%d:%d',
+                        $kind,
+                        $application->user_id,
+                        $application->{$targetColumn},
+                    );
+
+                    if (isset($seen[$key])) {
+                        continue;
+                    }
+
+                    DB::table('website_staff_applications')
+                        ->where('id', $application->id)
+                        ->update(['application_key' => $key]);
+
+                    $seen[$key] = true;
+                }
+            });
+    }
+};

--- a/tests/Feature/Community/ApplicationsTest.php
+++ b/tests/Feature/Community/ApplicationsTest.php
@@ -53,7 +53,12 @@ test('a user can apply for an open staff position once', function () {
         ->assertRedirect(route('staff-applications.index'))
         ->assertSessionHas('success');
 
-    expect(WebsiteStaffApplications::where('user_id', $this->user->id)->count())->toBe(1);
+    $application = WebsiteStaffApplications::where('user_id', $this->user->id)->first();
+
+    expect($application)
+        ->not->toBeNull()
+        ->and($application->application_key)
+        ->toBe("rank:{$this->user->id}:{$position->permission_id}");
 
     $this->actingAs($this->user)
         ->post(route('staff-applications.store', $position), [
@@ -93,4 +98,33 @@ test('a team position rejects the rank application flow', function () {
             'content' => 'Wrong flow for this position kind.',
         ])
         ->assertNotFound();
+});
+
+test('an application cannot be submitted outside the open period', function () {
+    $position = openRankPosition();
+    $position->update(['apply_to' => now()->subMinute()]);
+
+    $this->actingAs($this->user)
+        ->get(route('staff-applications.show', $position))
+        ->assertNotFound();
+
+    $this->actingAs($this->user)
+        ->post(route('staff-applications.store', $position), [
+            'content' => 'This position has already closed.',
+        ])
+        ->assertNotFound();
+
+    expect(WebsiteStaffApplications::where('user_id', $this->user->id)->exists())->toBeFalse();
+});
+
+test('application content has a bounded size', function () {
+    $position = openTeamPosition();
+
+    $this->actingAs($this->user)
+        ->post(route('team-applications.store', $position), [
+            'content' => str_repeat('a', 5001),
+        ])
+        ->assertSessionHasErrors('content');
+
+    expect(WebsiteStaffApplications::where('user_id', $this->user->id)->exists())->toBeFalse();
 });

--- a/tests/Feature/Community/ApplicationsTest.php
+++ b/tests/Feature/Community/ApplicationsTest.php
@@ -117,6 +117,27 @@ test('an application cannot be submitted outside the open period', function () {
     expect(WebsiteStaffApplications::where('user_id', $this->user->id)->exists())->toBeFalse();
 });
 
+test('a position without date bounds remains open for applications', function () {
+    $position = openRankPosition();
+    $position->update([
+        'apply_from' => null,
+        'apply_to' => null,
+    ]);
+
+    $this->actingAs($this->user)
+        ->get(route('staff-applications.show', $position))
+        ->assertOk();
+
+    $this->actingAs($this->user)
+        ->post(route('staff-applications.store', $position), [
+            'content' => 'I would love to help moderate the hotel.',
+        ])
+        ->assertSessionHas('success');
+
+    expect($position->fresh()->isAcceptingApplications())->toBeTrue()
+        ->and(WebsiteStaffApplications::where('user_id', $this->user->id)->exists())->toBeTrue();
+});
+
 test('application content has a bounded size', function () {
     $position = openTeamPosition();
 


### PR DESCRIPTION
## Summary
- reject staff and team submissions outside the configured application window
- route both flows through the existing authenticated form request with bounded content and CAPTCHA validation
- enforce race-safe one-application-per-user-and-target keys at the database layer
- preserve historical duplicate rows while assigning the earliest valid row as the canonical keyed application
- move submission behavior into one domain action and remove controller-level check-then-insert races

## Verification
- `vendor/bin/pest` - 143 passed, 407 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- migration apply, rollback, and reapply against MariaDB
- verified two legacy duplicate rows remain after migration with one canonical key
- `vendor/bin/pint`
- `git diff --check`