### PR TITLE
fix: defer runtime dependency initialization

### DIFF
--- a/app/Http/Controllers/Community/LeaderboardController.php
+++ b/app/Http/Controllers/Community/LeaderboardController.php
@@ -14,25 +14,20 @@ class LeaderboardController extends Controller
 {
     private const SIZE = 9;
 
-    /**
-     * @var array<int, int>
-     */
-    private array $staffIds;
+    public function __invoke(
+        CurrencyRepository $currencies,
+        PlayerStatsRepository $stats,
+        StaffService $staffService,
+    ): View {
+        $staffIds = $staffService->fetchEmployeeIds();
 
-    public function __construct(private readonly StaffService $staffService)
-    {
-        $this->staffIds = $this->staffService->fetchEmployeeIds();
-    }
-
-    public function __invoke(CurrencyRepository $currencies, PlayerStatsRepository $stats): View
-    {
         return view('leaderboard', [
-            'credits' => $currencies->topBy(CurrencyTypes::Credits, self::SIZE, $this->staffIds),
-            'duckets' => $currencies->topBy(CurrencyTypes::Duckets, self::SIZE, $this->staffIds),
-            'diamonds' => $currencies->topBy(CurrencyTypes::Diamonds, self::SIZE, $this->staffIds),
-            'mostOnline' => $stats->topBy(Stat::OnlineTime, self::SIZE, $this->staffIds),
-            'respectsReceived' => $stats->topBy(Stat::RespectsReceived, self::SIZE, $this->staffIds),
-            'achievementScores' => $stats->topBy(Stat::AchievementScore, self::SIZE, $this->staffIds),
+            'credits' => $currencies->topBy(CurrencyTypes::Credits, self::SIZE, $staffIds),
+            'duckets' => $currencies->topBy(CurrencyTypes::Duckets, self::SIZE, $staffIds),
+            'diamonds' => $currencies->topBy(CurrencyTypes::Diamonds, self::SIZE, $staffIds),
+            'mostOnline' => $stats->topBy(Stat::OnlineTime, self::SIZE, $staffIds),
+            'respectsReceived' => $stats->topBy(Stat::RespectsReceived, self::SIZE, $staffIds),
+            'achievementScores' => $stats->topBy(Stat::AchievementScore, self::SIZE, $staffIds),
         ]);
     }
 }

--- a/app/Http/Controllers/Shop/PaypalController.php
+++ b/app/Http/Controllers/Shop/PaypalController.php
@@ -19,11 +19,9 @@ class PaypalController extends Controller
 
     private const STATUS_COMPLETED = 'COMPLETED';
 
-    public function __construct(private readonly PayPalClient $provider) {}
-
-    public function process(AccountTopupFormRequest $request): Response|RedirectResponse
+    public function process(AccountTopupFormRequest $request, PayPalClient $provider): Response|RedirectResponse
     {
-        $response = $this->provider->createOrder($this->buildOrderData($request->integer('amount')));
+        $response = $provider->createOrder($this->buildOrderData($request->integer('amount')));
 
         $approvalUrl = isset($response['id']) ? $this->approvalUrl($response['links'] ?? []) : null;
 
@@ -89,7 +87,7 @@ class PaypalController extends Controller
         return to_route('shop.index')->withErrors(['message' => $response['message'] ?? __('Something went wrong')]);
     }
 
-    public function successful(Request $request): Response
+    public function successful(Request $request, PayPalClient $provider): Response
     {
         $request->validate([
             'token' => 'required',
@@ -107,7 +105,7 @@ class PaypalController extends Controller
             return to_route('shop.index')->with('success', __('Transaction successful'));
         }
 
-        $response = $this->provider->capturePaymentOrder($request['token']);
+        $response = $provider->capturePaymentOrder($request['token']);
         $capture = data_get($response, 'purchase_units.0.payments.captures.0');
 
         if (! isset($response['status']) || $capture === null) {

--- a/app/Http/Controllers/User/AccountSettingsController.php
+++ b/app/Http/Controllers/User/AccountSettingsController.php
@@ -13,8 +13,6 @@ use Illuminate\View\View;
 
 class AccountSettingsController extends Controller
 {
-    public function __construct(private readonly SessionService $sessionService, private readonly Rcon $rconService) {}
-
     public function edit(): View
     {
         return view('user.settings.account', [
@@ -22,16 +20,16 @@ class AccountSettingsController extends Controller
         ]);
     }
 
-    public function sessionLogs(Request $request): View
+    public function sessionLogs(Request $request, SessionService $sessionService): View
     {
-        $sessions = $this->sessionService->fetchSessionLogs($request);
+        $sessions = $sessionService->fetchSessionLogs($request);
 
         return view('user.settings.session-logs', [
             'logs' => $sessions,
         ]);
     }
 
-    public function update(AccountSettingsFormRequest $request): RedirectResponse
+    public function update(AccountSettingsFormRequest $request, Rcon $rcon): RedirectResponse
     {
         $user = Auth::user();
 
@@ -39,7 +37,7 @@ class AccountSettingsController extends Controller
             return redirect()->back()->withErrors('User not found');
         }
 
-        if (! $this->rconService->isConnected() && $user->online) {
+        if (! $rcon->isConnected() && $user->online) {
             return back()->withErrors('You must be offline to change your account settings');
         }
 
@@ -51,7 +49,7 @@ class AccountSettingsController extends Controller
         $motto = (string) $request->input('motto');
 
         if ($user->motto !== $motto) {
-            $this->rconService->setMotto($user, $motto);
+            $rcon->setMotto($user, $motto);
             $user->update(['motto' => $motto]);
         }
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Http;
 
 use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\BannedMiddleware;
+use App\Http\Middleware\ConfigureRuntimeFilesystems;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\EnsureEmulatorFeature;
 use App\Http\Middleware\FindRetrosMiddleware;
@@ -54,6 +55,7 @@ class Kernel extends HttpKernel
         ValidatePostSize::class,
         TrimStrings::class,
         ConvertEmptyStringsToNull::class,
+        ConfigureRuntimeFilesystems::class,
         SetThemeMiddleware::class,
         InstallationMiddleware::class,
     ];

--- a/app/Http/Middleware/ConfigureRuntimeFilesystems.php
+++ b/app/Http/Middleware/ConfigureRuntimeFilesystems.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\SettingsService;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\Response;
+
+class ConfigureRuntimeFilesystems
+{
+    public function __construct(private readonly SettingsService $settings) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        Config::set(
+            'filesystems.disks.badges.root',
+            $this->settings->getOrDefault('badge_path_filesystem', '/var/www/gamedata/c_images/album1584'),
+        );
+        Config::set(
+            'filesystems.disks.ads.root',
+            $this->settings->getOrDefault('ads_path_filesystem', '/var/www/gamedata/custom'),
+        );
+
+        Storage::forgetDisk(['badges', 'ads']);
+
+        return $next($request);
+    }
+}

--- a/app/Models/Miscellaneous/WebsitePermission.php
+++ b/app/Models/Miscellaneous/WebsitePermission.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Miscellaneous;
 
+use App\Services\PermissionsService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -28,4 +29,10 @@ use Illuminate\Support\Carbon;
 class WebsitePermission extends Model
 {
     protected $guarded = ['id'];
+
+    protected static function booted(): void
+    {
+        static::saved(fn () => PermissionsService::clearCache());
+        static::deleted(fn () => PermissionsService::clearCache());
+    }
 }

--- a/app/Models/WebsiteHousekeepingPermission.php
+++ b/app/Models/WebsiteHousekeepingPermission.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Services\HousekeepingPermissionsService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
@@ -28,4 +29,10 @@ use Illuminate\Support\Carbon;
 class WebsiteHousekeepingPermission extends Model
 {
     protected $guarded = ['id'];
+
+    protected static function booted(): void
+    {
+        static::saved(fn () => HousekeepingPermissionsService::clearCache());
+        static::deleted(fn () => HousekeepingPermissionsService::clearCache());
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ use App\Contracts\Rcon;
 use App\Models\WebsiteDrawBadge;
 use App\Observers\WebsiteDrawBadgeObserver;
 use App\Services\AfterCommitRcon;
+use App\Services\HousekeepingPermissionsService;
 use App\Services\InstallationService;
 use App\Services\PermissionsService;
 use App\Services\RconService;
@@ -14,7 +15,6 @@ use App\Services\ViteService;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Vite;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Blaze\Blaze;
@@ -45,6 +45,11 @@ class AppServiceProvider extends ServiceProvider
         $this->app->singleton(
             PermissionsService::class,
             fn () => new PermissionsService,
+        );
+
+        $this->app->singleton(
+            HousekeepingPermissionsService::class,
+            fn () => new HousekeepingPermissionsService,
         );
 
         // Wrapped so RCON sends inside a DB transaction only fire once it
@@ -83,13 +88,6 @@ class AppServiceProvider extends ServiceProvider
         Table::configureUsing(function (Table $table) {
             $table->paginated([10, 25, 50]);
         });
-
-        $settingsService = app(SettingsService::class);
-        $badgePath = $settingsService->getOrDefault('badge_path_filesystem', '/var/www/gamedata/c_images/album1584');
-        Config::set('filesystems.disks.badges.root', $badgePath);
-
-        $adsPath = $settingsService->getOrDefault('ads_path_filesystem', '/var/www/gamedata/custom');
-        Config::set('filesystems.disks.ads.root', $adsPath);
 
         WebsiteDrawBadge::observe(WebsiteDrawBadgeObserver::class);
     }

--- a/app/Services/HousekeepingPermissionsService.php
+++ b/app/Services/HousekeepingPermissionsService.php
@@ -4,22 +4,39 @@ namespace App\Services;
 
 use App\Models\WebsiteHousekeepingPermission;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 
 class HousekeepingPermissionsService
 {
-    public Collection $permissions;
+    private ?Collection $permissions = null;
 
-    public function __construct()
+    private function permissions(): Collection
     {
-        $this->permissions = WebsiteHousekeepingPermission::all()->pluck('min_rank', 'permission');
+        if ($this->permissions !== null) {
+            return $this->permissions;
+        }
+
+        $data = Cache::remember('housekeeping_permissions', now()->addMinutes(30), function (): array {
+            return WebsiteHousekeepingPermission::query()->pluck('min_rank', 'permission')->toArray();
+        });
+
+        return $this->permissions = collect($data);
     }
 
     public function getOrDefault(string $permissionName, bool $default = false): bool
     {
-        if (! $this->permissions->has($permissionName)) {
+        $permissions = $this->permissions();
+
+        if (! $permissions->has($permissionName)) {
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $this->permissions->get($permissionName);
+        return auth()->check() && auth()->user()->rank >= (int) $permissions->get($permissionName);
+    }
+
+    public static function clearCache(): void
+    {
+        Cache::forget('housekeeping_permissions');
+        app()->forgetInstance(self::class);
     }
 }

--- a/app/Services/PermissionsService.php
+++ b/app/Services/PermissionsService.php
@@ -8,23 +8,35 @@ use Illuminate\Support\Facades\Cache;
 
 class PermissionsService
 {
-    public Collection $permissions;
+    private ?Collection $permissions = null;
 
-    public function __construct()
+    private function permissions(): Collection
     {
-        $data = Cache::remember('website_permissions', now()->addMinutes(30), function () {
+        if ($this->permissions !== null) {
+            return $this->permissions;
+        }
+
+        $data = Cache::remember('website_permissions', now()->addMinutes(30), function (): array {
             return WebsitePermission::all()->pluck('min_rank', 'permission')->toArray();
         });
 
-        $this->permissions = collect($data);
+        return $this->permissions = collect($data);
     }
 
     public function getOrDefault(string $permissionName, bool $default = false): bool
     {
-        if (! $this->permissions->has($permissionName)) {
+        $permissions = $this->permissions();
+
+        if (! $permissions->has($permissionName)) {
             return $default;
         }
 
-        return auth()->check() && auth()->user()->rank >= (int) $this->permissions->get($permissionName);
+        return auth()->check() && auth()->user()->rank >= (int) $permissions->get($permissionName);
+    }
+
+    public static function clearCache(): void
+    {
+        Cache::forget('website_permissions');
+        app()->forgetInstance(self::class);
     }
 }

--- a/app/Services/RconService.php
+++ b/app/Services/RconService.php
@@ -14,23 +14,11 @@ class RconService implements Rcon
 
     protected bool $isConnected = false;
 
-    /**
-     * @var array{ip: mixed, port: int}
-     */
-    protected array $config;
-
-    public function __construct()
-    {
-        $this->config = [
-            'ip' => setting('rcon_ip'),
-            'port' => (int) setting('rcon_port'),
-        ];
-
-        $this->initialize();
-    }
+    protected bool $connectionAttempted = false;
 
     private function initialize(): void
     {
+        $this->connectionAttempted = true;
         $socket = @socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
 
         if ($socket === false) {
@@ -43,7 +31,7 @@ class RconService implements Rcon
 
         $this->socket = $socket;
 
-        if (! @socket_connect($this->socket, $this->config['ip'], $this->config['port'])) {
+        if (! @socket_connect($this->socket, (string) setting('rcon_ip'), (int) setting('rcon_port'))) {
             Log::error('RCON connection failed: ' . socket_strerror(socket_last_error()));
 
             $this->closeConnection();
@@ -66,12 +54,16 @@ class RconService implements Rcon
 
     public function isConnected(): bool
     {
+        if (! $this->connectionAttempted) {
+            $this->initialize();
+        }
+
         return $this->isConnected;
     }
 
     public function sendCommand(string $command, ?array $data = null): bool
     {
-        if (! $this->isConnected) {
+        if (! $this->isConnected()) {
             Log::error('RCON command failed: Not connected');
 
             $this->closeConnection();


### PR DESCRIPTION
## Summary
- resolve PayPal, leaderboard, session, and RCON dependencies only in actions that use them
- connect to RCON lazily instead of opening a socket during container resolution
- lazily cache permission maps and invalidate them when permission records change
- configure database-backed filesystem roots in HTTP middleware instead of application boot

## Verification
- `vendor/bin/pest` - 141 passed, 400 assertions
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test ...`
- `DB_HOST=127.0.0.1 DB_PORT=1 CACHE_STORE=array php artisan route:list --except-vendor`
- `git diff --cached --check`