### PR TITLE
refactor: restore standard user persistence

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -439,15 +439,6 @@ class User extends Authenticatable implements FilamentUser, HasName
             ->dontSubmitEmptyLogs();
     }
 
-    public function save(array $options = []): bool
-    {
-        if (! $this->isDirty()) {
-            return true;
-        }
-
-        return parent::save($options);
-    }
-
     public function hasAppliedForTeam(int $teamId): bool
     {
         if (! $teamId) {


### PR DESCRIPTION
## Summary
- remove the custom User::save override
- restore Laravel model event and relationship-touch semantics
- rely on Eloquent built-in dirty checking to avoid unnecessary updates

## Verification
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test app/Models/User.php`