### PR TITLE
refactor: pass article actors explicitly

### DIFF
--- a/app/Livewire/ArticleComments.php
+++ b/app/Livewire/ArticleComments.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\Models\Articles\WebsiteArticle;
 use App\Models\Articles\WebsiteArticleComment;
+use App\Models\User;
 use App\Rules\WebsiteWordfilterRule;
 use Illuminate\View\View;
 use Livewire\Attributes\Locked;
@@ -23,11 +24,14 @@ class ArticleComments extends Component
 
     public function postComment(): void
     {
+        $user = auth()->user();
+        abort_unless($user instanceof User, 403);
+
         $this->validate([
             'comment' => ['required', 'string', 'min:2', 'max:255', new WebsiteWordfilterRule],
         ]);
 
-        if ($this->article->userHasReachedArticleCommentLimit()) {
+        if ($this->article->userHasReachedArticleCommentLimit($user)) {
             $this->addError('comment', __('You can only comment :amount times per article', ['amount' => setting('max_comment_per_article')]));
 
             return;
@@ -40,7 +44,7 @@ class ArticleComments extends Component
         }
 
         $this->article->comments()->create([
-            'user_id' => auth()->id(),
+            'user_id' => $user->id,
             'comment' => $this->comment,
         ]);
 

--- a/app/Livewire/ArticleReactions.php
+++ b/app/Livewire/ArticleReactions.php
@@ -62,6 +62,7 @@ class ArticleReactions extends Component
         }
 
         $this->article->reactions()->create([
+            'user_id' => $user->id,
             'reaction' => $reaction,
         ]);
 

--- a/app/Models/Articles/WebsiteArticle.php
+++ b/app/Models/Articles/WebsiteArticle.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\Auth;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -92,9 +91,9 @@ class WebsiteArticle extends Model
         return $this->hasMany(WebsiteArticleComment::class, 'article_id');
     }
 
-    public function userHasReachedArticleCommentLimit(): bool
+    public function userHasReachedArticleCommentLimit(User $user): bool
     {
-        return $this->comments()->where('user_id', '=', Auth::id())->count() >= (int) setting('max_comment_per_article');
+        return $this->comments()->where('user_id', $user->id)->count() >= (int) setting('max_comment_per_article');
     }
 
     protected static function boot()

--- a/app/Models/Articles/WebsiteArticleReaction.php
+++ b/app/Models/Articles/WebsiteArticleReaction.php
@@ -31,7 +31,11 @@ class WebsiteArticleReaction extends Model
 {
     use HasFactory;
 
-    protected $guarded = [];
+    protected $fillable = [
+        'user_id',
+        'reaction',
+        'active',
+    ];
 
     public $timestamps = false;
 
@@ -46,15 +50,6 @@ class WebsiteArticleReaction extends Model
             ->where('article_id', $articleId)
             ->where('reaction', $reaction)
             ->first();
-    }
-
-    public static function boot()
-    {
-        parent::boot();
-
-        static::creating(function ($model) {
-            $model->user_id = auth()->id();
-        });
     }
 
     public function article(): BelongsTo

--- a/app/Services/Articles/CommentService.php
+++ b/app/Services/Articles/CommentService.php
@@ -4,6 +4,7 @@ namespace App\Services\Articles;
 
 use App\Models\Articles\WebsiteArticle;
 use App\Models\Articles\WebsiteArticleComment;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 
@@ -11,7 +12,10 @@ class CommentService
 {
     public function store(string $comment, WebsiteArticle $article): mixed
     {
-        if ($article->userHasReachedArticleCommentLimit()) {
+        $user = Auth::user();
+        abort_unless($user instanceof User, 403);
+
+        if ($article->userHasReachedArticleCommentLimit($user)) {
             return redirect()->back()->withErrors([
                 'message' => __('You can only comment :amount times per article', ['amount' => setting('max_comment_per_article')]),
             ]);
@@ -24,7 +28,7 @@ class CommentService
         }
 
         return $article->comments()->create([
-            'user_id' => Auth::id(),
+            'user_id' => $user->id,
             'comment' => $comment,
         ]);
     }

--- a/app/Services/Articles/ReactionService.php
+++ b/app/Services/Articles/ReactionService.php
@@ -23,6 +23,7 @@ class ReactionService
             $existingReaction->update(['active' => ! $existingReaction->active]);
         } else {
             $article->reactions()->create([
+                'user_id' => $user->id,
                 'reaction' => $reaction,
             ]);
         }

--- a/resources/views/livewire/article-comments.blade.php
+++ b/resources/views/livewire/article-comments.blade.php
@@ -1,8 +1,9 @@
 @php($theme = setting('theme', 'dusk'))
+@php($viewer = auth()->user())
 
 <div class="space-y-4">
     @if ($article->can_comment)
-        @if (auth()->check() && !$article->userHasReachedArticleCommentLimit())
+        @if ($viewer && !$article->userHasReachedArticleCommentLimit($viewer))
             <x-content.content-card icon="hotel-icon">
                 <x-slot:title>
                     {{ __('Post a comment') }}

--- a/tests/Feature/Community/ArticleInteractionsTest.php
+++ b/tests/Feature/Community/ArticleInteractionsTest.php
@@ -72,7 +72,8 @@ test('a reader can toggle a reaction', function () {
         ->post(route('article.toggle-reaction', $article->slug), ['reaction' => 'like'])
         ->assertOk();
 
-    expect($article->reactions()->count())->toBe(1);
+    expect($article->reactions()->count())->toBe(1)
+        ->and($article->reactions()->first()->user_id)->toBe($this->reader->id);
 
     $this->actingAs($this->reader)
         ->post(route('article.toggle-reaction', $article->slug), ['reaction' => 'like'])


### PR DESCRIPTION
## Summary
- remove request-global authentication from article model behavior
- assign reaction ownership explicitly at each creation boundary
- restrict reaction mass assignment to intended fields
- reject guest Livewire comment submissions before model access

## Verification
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test app/Livewire/ArticleComments.php app/Livewire/ArticleReactions.php app/Models/Articles/WebsiteArticle.php app/Models/Articles/WebsiteArticleReaction.php app/Services/Articles/CommentService.php app/Services/Articles/ReactionService.php tests/Feature/Community/ArticleInteractionsTest.php`
- `npx prettier resources/views/livewire/article-comments.blade.php --check`