### PR TITLE
fix: keep home widgets current

### DIFF
--- a/app/Services/Home/HomeService.php
+++ b/app/Services/Home/HomeService.php
@@ -7,7 +7,6 @@ use App\Enums\HomeItemType;
 use App\Models\Home\HomeItem;
 use App\Models\Home\UserHomeItem;
 use App\Models\User;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 
 class HomeService
@@ -168,23 +167,9 @@ class HomeService
             return null;
         }
 
-        $cacheKey = "user_{$user->id}_widget_{$item->id}_html";
-        $cacheDuration = in_array($item->widget_type, ['my-rating', 'my-guestbook']) ? 0 : 300;
+        $user = $this->loadWidgetData($user, $item);
 
-        $render = function () use ($user, $item, $viewName): string {
-            $user = $this->loadWidgetData($user, $item);
-
-            return view($viewName, compact('item', 'user'))->render();
-        };
-
-        return $cacheDuration > 0
-            ? Cache::remember($cacheKey, $cacheDuration, $render)
-            : $render();
-    }
-
-    public function clearWidgetCache(User $user, UserHomeItem $widget): void
-    {
-        Cache::forget("user_{$user->id}_widget_{$widget->id}_html");
+        return view($viewName, compact('item', 'user'))->render();
     }
 
     private function loadWidgetData(User $user, UserHomeItem $item): User

--- a/tests/Feature/Home/HomeInteractionsTest.php
+++ b/tests/Feature/Home/HomeInteractionsTest.php
@@ -74,3 +74,36 @@ test('a visitor can leave a home message', function () {
 
     expect($this->owner->receivedHomeMessages()->count())->toBe(1);
 });
+
+test('profile widgets reflect user changes immediately', function () {
+    $this->owner->update(['motto' => 'The original motto']);
+
+    $widget = HomeItem::create([
+        'name' => 'My Profile',
+        'type' => HomeItemType::Widget,
+        'currency_type' => CurrencyTypes::Duckets,
+        'price' => 25,
+        'image' => 'widgets/profile.png',
+        'enabled' => true,
+        'order' => 0,
+    ]);
+    $placedWidget = $this->owner->homeItems()->create([
+        'home_item_id' => $widget->id,
+        'placed' => true,
+        'theme' => 'default',
+    ]);
+
+    $this->getJson(route('home.widget-content', [$this->owner->username, $placedWidget->id]))
+        ->assertOk()
+        ->assertJsonPath('content', fn (string $content): bool => str_contains($content, 'The original motto'));
+
+    $this->owner->update(['motto' => 'A freshly updated motto']);
+
+    $this->getJson(route('home.widget-content', [$this->owner->username, $placedWidget->id]))
+        ->assertOk()
+        ->assertJsonPath(
+            'content',
+            fn (string $content): bool => str_contains($content, 'A freshly updated motto')
+                && ! str_contains($content, 'The original motto'),
+        );
+});


### PR DESCRIPTION
## Summary
- remove rendered home-widget fragments that had no reliable invalidation path
- always render profile, room, badge, friend, rating, and guestbook data from current state
- verify profile changes appear on the immediately following widget request

## Verification
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test app/Services/Home/HomeService.php tests/Feature/Home/HomeInteractionsTest.php`