### PR TITLE
fix: allowlist user mass assignment

### DIFF
--- a/app/Filament/Resources/User/Users/UserResource.php
+++ b/app/Filament/Resources/User/Users/UserResource.php
@@ -111,11 +111,6 @@ class UserResource extends Resource
                                     ->label(__('filament::resources.inputs.referral_code'))
                                     ->disabled(),
 
-                                TextInput::make('referrer_code')
-                                    ->label(__('filament::resources.inputs.referrer_code'))
-                                    ->nullable()
-                                    ->maxLength(15),
-
                                 Select::make('team_id')
                                     ->native(false)
                                     ->label(__('filament::resources.inputs.team_id'))

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -199,7 +199,6 @@ class User extends Authenticatable implements FilamentUser, HasName
         'ip_current',
         'home_room',
         'referral_code',
-        'referrer_code',
         'extra_rank',
         'team_id',
         'hidden_staff',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -178,24 +178,33 @@ class User extends Authenticatable implements FilamentUser, HasName
 
     public $timestamps = false;
 
-    /**
-     * Economy and security columns are only ever written through dedicated
-     * paths (increment(), forceFill()), never mass-assignment - guard them so a
-     * stray fill() of request data cannot tamper with balances or 2FA secrets.
-     */
-    protected $guarded = [
-        'id',
-        'website_balance',
-        'pixels',
-        'points',
-        'vip_points',
-        'activity_points',
-        'gotw_points',
-        'machine_id',
-        'pincode',
-        'secret_key',
-        'two_factor_secret',
-        'two_factor_recovery_codes',
+    protected $fillable = [
+        'username',
+        'real_name',
+        'password',
+        'mail',
+        'mail_verified',
+        'account_created',
+        'account_day_of_birth',
+        'last_login',
+        'last_online',
+        'motto',
+        'look',
+        'gender',
+        'rank',
+        'credits',
+        'online',
+        'auth_ticket',
+        'ip_register',
+        'ip_current',
+        'home_room',
+        'referral_code',
+        'referrer_code',
+        'extra_rank',
+        'team_id',
+        'hidden_staff',
+        'two_factor_confirmed',
+        'two_factor_confirmed_at',
     ];
 
     protected $hidden = [

--- a/tests/Feature/User/AccountSettingsTest.php
+++ b/tests/Feature/User/AccountSettingsTest.php
@@ -7,6 +7,22 @@ beforeEach(function () {
     installHotel();
 });
 
+test('security and economy fields cannot be mass assigned', function () {
+    $user = new User;
+
+    $user->fill([
+        'username' => 'AllowedName',
+        'website_balance' => 500,
+        'machine_id' => 'attacker-controlled',
+        'two_factor_secret' => 'attacker-controlled',
+    ]);
+
+    expect($user->username)->toBe('AllowedName')
+        ->and($user->isDirty('website_balance'))->toBeFalse()
+        ->and($user->isDirty('machine_id'))->toBeFalse()
+        ->and($user->isDirty('two_factor_secret'))->toBeFalse();
+});
+
 test('an offline user can update their motto', function () {
     $user = User::factory()->create(['motto' => 'Old motto', 'online' => '0']);
 


### PR DESCRIPTION
## Summary
- replace the User model denylist with an explicit mass-assignment allowlist
- preserve intentional registration, account, SSO, package, and staff update paths
- default-deny economy balances, machine identifiers, pins, secrets, and future columns
- add regression coverage for protected security and economy fields

## Verification
- `vendor/bin/pest`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=1G`
- `vendor/bin/pint --test app/Models/User.php tests/Feature/User/AccountSettingsTest.php`