### PR TITLE
fix: make migrations data safe and reversible

### DIFF
--- a/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php
@@ -12,28 +12,25 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            if (columnExists('users', 'two_factor_secret')) {
-                Schema::dropColumns('users', 'two_factor_secret');
+        $addSecret = ! Schema::hasColumn('users', 'two_factor_secret');
+        $addRecoveryCodes = ! Schema::hasColumn('users', 'two_factor_recovery_codes');
+        $addConfirmedAt = Fortify::confirmsTwoFactorAuthentication()
+            && ! Schema::hasColumn('users', 'two_factor_confirmed_at');
+
+        Schema::table('users', function (Blueprint $table) use ($addConfirmedAt, $addRecoveryCodes, $addSecret) {
+            if ($addSecret) {
+                $table->text('two_factor_secret')
+                    ->after('password')
+                    ->nullable();
             }
 
-            if (columnExists('users', 'two_factor_recovery_codes')) {
-                Schema::dropColumns('users', 'two_factor_recovery_codes');
+            if ($addRecoveryCodes) {
+                $table->text('two_factor_recovery_codes')
+                    ->after('two_factor_secret')
+                    ->nullable();
             }
 
-            $table->text('two_factor_secret')
-                ->after('password')
-                ->nullable();
-
-            $table->text('two_factor_recovery_codes')
-                ->after('two_factor_secret')
-                ->nullable();
-
-            if (Fortify::confirmsTwoFactorAuthentication()) {
-                if (columnExists('users', 'two_factor_confirmed_at')) {
-                    Schema::dropColumns('users', 'two_factor_confirmed_at');
-                }
-
+            if ($addConfirmedAt) {
                 $table->timestamp('two_factor_confirmed_at')
                     ->after('two_factor_recovery_codes')
                     ->nullable();

--- a/database/migrations/2022_08_06_022347_add_referral_code_to_users_table.php
+++ b/database/migrations/2022_08_06_022347_add_referral_code_to_users_table.php
@@ -10,13 +10,11 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            if (columnExists('users', 'referral_code')) {
-                Schema::dropColumns('users', 'referral_code');
-            }
-
-            $table->string('referral_code')->nullable()->unique()->after('home_room');
-        });
+        if (! Schema::hasColumn('users', 'referral_code')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('referral_code')->nullable()->unique()->after('home_room');
+            });
+        }
 
         foreach (User::whereNull('referral_code')->get() as $user) {
             $user->update(['referral_code' => sprintf('%s%s', $user->id, Str::random(8))]);
@@ -25,10 +23,10 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
+        if (Schema::hasColumn('users', 'referral_code')) {
             Schema::table('users', function (Blueprint $table) {
                 $table->dropColumn('referral_code');
             });
-        });
+        }
     }
 };

--- a/database/migrations/2022_08_14_210602_add_hidden_staff_to_users_table.php
+++ b/database/migrations/2022_08_14_210602_add_hidden_staff_to_users_table.php
@@ -8,12 +8,17 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            if (columnExists('users', 'hidden_staff')) {
-                Schema::dropColumns('users', 'hidden_staff');
-            }
+        if (! Schema::hasColumn('users', 'hidden_staff')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->boolean('hidden_staff')->after('rank')->default(false);
+            });
+        }
+    }
 
-            $table->boolean('hidden_staff')->after('rank')->default(false);
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('hidden_staff');
         });
     }
 };

--- a/database/migrations/2022_08_14_210623_add_hidden_rank_to_permissions_table.php
+++ b/database/migrations/2022_08_14_210623_add_hidden_rank_to_permissions_table.php
@@ -8,12 +8,17 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('permissions', function (Blueprint $table) {
-            if (columnExists('permissions', 'hidden_rank')) {
-                Schema::dropColumns('permissions', 'hidden_rank');
-            }
+        if (! Schema::hasColumn('permissions', 'hidden_rank')) {
+            Schema::table('permissions', function (Blueprint $table) {
+                $table->boolean('hidden_rank')->after('rank_name')->default(false);
+            });
+        }
+    }
 
-            $table->boolean('hidden_rank')->after('rank_name')->default(false);
+    public function down(): void
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->dropColumn('hidden_rank');
         });
     }
 };

--- a/database/migrations/2022_08_25_225959_change_user_id_on_website_articles_table.php
+++ b/database/migrations/2022_08_25_225959_change_user_id_on_website_articles_table.php
@@ -13,4 +13,12 @@ return new class extends Migration
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
         });
     }
+
+    public function down(): void
+    {
+        Schema::table('website_articles', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->string('user_id')->nullable(false)->change();
+        });
+    }
 };

--- a/database/migrations/2022_09_17_225245_add_staff_color_and_description_to_permissions_table.php
+++ b/database/migrations/2022_09_17_225245_add_staff_color_and_description_to_permissions_table.php
@@ -8,17 +8,23 @@ return new class extends Migration
 {
     public function up(): void
     {
+        if (! Schema::hasColumn('permissions', 'job_description')) {
+            Schema::table('permissions', function (Blueprint $table) {
+                $table->string('job_description')->default('Here to help')->after('badge');
+            });
+        }
+
+        if (! Schema::hasColumn('permissions', 'staff_color')) {
+            Schema::table('permissions', function (Blueprint $table) {
+                $table->string('staff_color', 8)->default('#327fa8')->after('job_description');
+            });
+        }
+    }
+
+    public function down(): void
+    {
         Schema::table('permissions', function (Blueprint $table) {
-            if (columnExists('permissions', 'job_description')) {
-                Schema::dropColumns('permissions', 'job_description');
-            }
-
-            if (columnExists('permissions', 'staff_color')) {
-                Schema::dropColumns('permissions', 'staff_color');
-            }
-
-            $table->string('job_description')->default('Here to help')->after('badge');
-            $table->string('staff_color', 8)->default('#327fa8')->after('job_description');
+            $table->dropColumn(['job_description', 'staff_color']);
         });
     }
 };

--- a/database/migrations/2022_09_25_153707_add_staff_background_to_permissions_table.php
+++ b/database/migrations/2022_09_25_153707_add_staff_background_to_permissions_table.php
@@ -8,17 +8,17 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('permissions', function (Blueprint $table) {
-            if (columnExists('permissions', 'staff_background')) {
-                Schema::dropColumns('permissions', 'staff_background');
-            }
-
-            $table->string('staff_background')->default('staff-bg.png')->after('staff_color');
-        });
+        if (! Schema::hasColumn('permissions', 'staff_background')) {
+            Schema::table('permissions', function (Blueprint $table) {
+                $table->string('staff_background')->default('staff-bg.png')->after('staff_color');
+            });
+        }
     }
 
     public function down(): void
     {
-        Schema::table('permissions', function (Blueprint $table) {});
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->dropColumn('staff_background');
+        });
     }
 };

--- a/database/migrations/2022_10_28_144239_add_two_factor_confirmed_to_users_table.php
+++ b/database/migrations/2022_10_28_144239_add_two_factor_confirmed_to_users_table.php
@@ -8,14 +8,19 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            if (columnExists('users', 'two_factor_confirmed')) {
-                Schema::dropColumns('users', 'two_factor_confirmed');
-            }
+        if (! Schema::hasColumn('users', 'two_factor_confirmed')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->boolean('two_factor_confirmed')
+                    ->after('two_factor_recovery_codes')
+                    ->default(false);
+            });
+        }
+    }
 
-            $table->boolean('two_factor_confirmed')
-                ->after('two_factor_recovery_codes')
-                ->default(false);
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('two_factor_confirmed');
         });
     }
 };

--- a/database/migrations/2022_11_29_141603_rename_website_permissions_columns.php
+++ b/database/migrations/2022_11_29_141603_rename_website_permissions_columns.php
@@ -8,7 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        DB::table('website_permissions')->truncate();
         Schema::table('website_permissions', function (Blueprint $table) {
             $table->renameColumn('key', 'permission');
         });
@@ -19,6 +18,21 @@ return new class extends Migration
 
         Schema::table('website_permissions', function (Blueprint $table) {
             $table->renameColumn('comment', 'description');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('website_permissions', function (Blueprint $table) {
+            $table->renameColumn('description', 'comment');
+        });
+
+        Schema::table('website_permissions', function (Blueprint $table) {
+            $table->renameColumn('min_rank', 'value');
+        });
+
+        Schema::table('website_permissions', function (Blueprint $table) {
+            $table->renameColumn('permission', 'key');
         });
     }
 };

--- a/database/migrations/2022_11_29_145239_add_teams_id_to_users_table.php
+++ b/database/migrations/2022_11_29_145239_add_teams_id_to_users_table.php
@@ -8,18 +8,25 @@ return new class extends Migration
 {
     public function up(): void
     {
-
-        if (Schema::hasColumn('users', 'team_id')) {
-            dropForeignKeyIfExists('users', 'team_id');
-            Schema::dropColumns('users', 'team_id');
+        if (! Schema::hasColumn('users', 'team_id')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->unsignedBigInteger('team_id')->nullable();
+            });
         }
 
-        Schema::table('users', function (Blueprint $table) {
-            if (! Schema::hasColumn('users', 'team_id')) {
-                $table->unsignedBigInteger('team_id')->nullable();
-            }
+        dropForeignKeyIfExists('users', 'team_id');
 
+        Schema::table('users', function (Blueprint $table) {
             $table->foreign('team_id')->references('id')->on('website_teams')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        dropForeignKeyIfExists('users', 'team_id');
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('team_id');
         });
     }
 };

--- a/database/migrations/2023_01_15_215807_add_deleted_at_to_website_articles_table.php
+++ b/database/migrations/2023_01_15_215807_add_deleted_at_to_website_articles_table.php
@@ -8,12 +8,17 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('website_articles', function (Blueprint $table) {
-            if (columnExists('website_articles', 'deleted_at')) {
-                Schema::dropColumns('website_articles', 'deleted_at');
-            }
+        if (! Schema::hasColumn('website_articles', 'deleted_at')) {
+            Schema::table('website_articles', function (Blueprint $table) {
+                $table->softDeletes()->after('updated_at');
+            });
+        }
+    }
 
-            $table->softDeletes()->after('updated_at');
+    public function down(): void
+    {
+        Schema::table('website_articles', function (Blueprint $table) {
+            $table->dropSoftDeletes();
         });
     }
 };

--- a/database/migrations/2023_01_16_171014_add_can_comment_to_website_articles_table.php
+++ b/database/migrations/2023_01_16_171014_add_can_comment_to_website_articles_table.php
@@ -8,12 +8,17 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('website_articles', function (Blueprint $table) {
-            if (columnExists('website_articles', 'can_comment')) {
-                Schema::dropColumns('website_articles', 'can_comment');
-            }
+        if (! Schema::hasColumn('website_articles', 'can_comment')) {
+            Schema::table('website_articles', function (Blueprint $table) {
+                $table->boolean('can_comment')->default(true)->after('image');
+            });
+        }
+    }
 
-            $table->boolean('can_comment')->default(true)->after('image');
+    public function down(): void
+    {
+        Schema::table('website_articles', function (Blueprint $table) {
+            $table->dropColumn('can_comment');
         });
     }
 };

--- a/database/migrations/2023_04_04_212429_create_website_installation_table.php
+++ b/database/migrations/2023_04_04_212429_create_website_installation_table.php
@@ -23,4 +23,9 @@ return new class extends Migration
             $table->timestamps();
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('website_installation');
+    }
 };

--- a/database/migrations/2023_04_07_231919_remove_can_apply_from_permissions_table.php
+++ b/database/migrations/2023_04_07_231919_remove_can_apply_from_permissions_table.php
@@ -14,4 +14,13 @@ return new class extends Migration
             }
         });
     }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('permissions', 'can_apply')) {
+            Schema::table('permissions', function (Blueprint $table) {
+                $table->boolean('can_apply')->default(false);
+            });
+        }
+    }
 };

--- a/database/migrations/2024_06_15_093658_add_category_id_to_website_shop_articles_table.php
+++ b/database/migrations/2024_06_15_093658_add_category_id_to_website_shop_articles_table.php
@@ -13,4 +13,11 @@ return new class extends Migration
             $table->foreignIdFor(WebsiteShopCategory::class)->after('id')->nullable();
         });
     }
+
+    public function down(): void
+    {
+        Schema::table('website_shop_articles', function (Blueprint $table) {
+            $table->dropColumn('website_shop_category_id');
+        });
+    }
 };

--- a/database/migrations/2024_06_16_122838_add_is_giftable_to_website_shop_articles_table.php
+++ b/database/migrations/2024_06_16_122838_add_is_giftable_to_website_shop_articles_table.php
@@ -12,4 +12,11 @@ return new class extends Migration
             $table->boolean('is_giftable')->default(true)->after('position');
         });
     }
+
+    public function down(): void
+    {
+        Schema::table('website_shop_articles', function (Blueprint $table) {
+            $table->dropColumn('is_giftable');
+        });
+    }
 };

--- a/database/migrations/2024_06_16_184358_change_value_column_type_on_website_settings_table.php
+++ b/database/migrations/2024_06_16_184358_change_value_column_type_on_website_settings_table.php
@@ -12,4 +12,11 @@ return new class extends Migration
             $table->text('value')->change();
         });
     }
+
+    public function down(): void
+    {
+        Schema::table('website_settings', function (Blueprint $table) {
+            $table->string('value')->change();
+        });
+    }
 };

--- a/database/migrations/2025_10_13_114314_add_team_to_website_staff_applications_table.php
+++ b/database/migrations/2025_10_13_114314_add_team_to_website_staff_applications_table.php
@@ -34,15 +34,21 @@ return new class extends Migration
 
     public function down(): void
     {
-        if ($this->indexExists('website_staff_applications', 'website_staff_applications_user_team_unique')) {
-            Schema::table('website_staff_applications', function (Blueprint $table) {
-                $table->dropUnique('website_staff_applications_user_team_unique');
-            });
-        }
-
         if ($this->foreignKeyExists('website_staff_applications', 'website_staff_applications_team_id_foreign')) {
             Schema::table('website_staff_applications', function (Blueprint $table) {
                 $table->dropForeign('website_staff_applications_team_id_foreign');
+            });
+        }
+
+        if ($this->indexExists('website_staff_applications', 'website_staff_applications_user_team_unique')) {
+            if (! $this->indexExists('website_staff_applications', 'website_staff_applications_user_id_index')) {
+                Schema::table('website_staff_applications', function (Blueprint $table) {
+                    $table->index('user_id');
+                });
+            }
+
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->dropUnique('website_staff_applications_user_team_unique');
             });
         }
 

--- a/database/migrations/2025_10_13_114411_add_team_support_to_website_open_positions_table.php
+++ b/database/migrations/2025_10_13_114411_add_team_support_to_website_open_positions_table.php
@@ -9,32 +9,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('website_open_positions', function (Blueprint $table) {
-            if (! Schema::hasColumn('website_open_positions', 'position_kind')) {
-                $table->string('position_kind', 20)->default('rank')->after('id');
-            }
-
-            if (! Schema::hasColumn('website_open_positions', 'team_id')) {
-                $table->unsignedBigInteger('team_id')->nullable()->after('permission_id');
-            }
-        });
-
-        // description -> TEXT (no doctrine/dbal)
-        DB::statement('ALTER TABLE website_open_positions MODIFY description TEXT NOT NULL');
-
-        // Unique indexes (allow multiple NULLs)
-        if (! $this->indexExists('website_open_positions', 'open_positions_unique_permission_id')) {
-            Schema::table('website_open_positions', function (Blueprint $table) {
-                $table->unique('permission_id', 'open_positions_unique_permission_id');
-            });
-        }
-        if (! $this->indexExists('website_open_positions', 'open_positions_unique_team_id')) {
-            Schema::table('website_open_positions', function (Blueprint $table) {
-                $table->unique('team_id', 'open_positions_unique_team_id');
-            });
-        }
-
-        // Optional FK to teams
         if (! $this->foreignKeyExists('website_open_positions', 'website_open_positions_team_id_foreign')) {
             Schema::table('website_open_positions', function (Blueprint $table) {
                 $table->foreign('team_id', 'website_open_positions_team_id_foreign')
@@ -46,45 +20,11 @@ return new class extends Migration
 
     public function down(): void
     {
-        if ($this->indexExists('website_open_positions', 'open_positions_unique_permission_id')) {
-            Schema::table('website_open_positions', function (Blueprint $table) {
-                $table->dropUnique('open_positions_unique_permission_id');
-            });
-        }
-        if ($this->indexExists('website_open_positions', 'open_positions_unique_team_id')) {
-            Schema::table('website_open_positions', function (Blueprint $table) {
-                $table->dropUnique('open_positions_unique_team_id');
-            });
-        }
-
         if ($this->foreignKeyExists('website_open_positions', 'website_open_positions_team_id_foreign')) {
             Schema::table('website_open_positions', function (Blueprint $table) {
                 $table->dropForeign('website_open_positions_team_id_foreign');
             });
         }
-
-        DB::statement('ALTER TABLE website_open_positions MODIFY description VARCHAR(255) NOT NULL');
-
-        Schema::table('website_open_positions', function (Blueprint $table) {
-            if (Schema::hasColumn('website_open_positions', 'team_id')) {
-                $table->dropColumn('team_id');
-            }
-            if (Schema::hasColumn('website_open_positions', 'position_kind')) {
-                $table->dropColumn('position_kind');
-            }
-        });
-    }
-
-    private function indexExists(string $table, string $index): bool
-    {
-        $db = DB::getDatabaseName();
-        $row = DB::selectOne('
-            SELECT COUNT(*) as cnt
-            FROM information_schema.statistics
-            WHERE table_schema = ? AND table_name = ? AND index_name = ?
-        ', [$db, $table, $index]);
-
-        return (int) ($row->cnt ?? 0) > 0;
     }
 
     private function foreignKeyExists(string $table, string $constraint): bool

--- a/database/migrations/2025_10_14_073736_add_status_to_website_staff_applications_table.php
+++ b/database/migrations/2025_10_14_073736_add_status_to_website_staff_applications_table.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -8,93 +9,79 @@ return new class extends Migration
 {
     public function up(): void
     {
-        DB::statement('ALTER TABLE website_staff_applications MODIFY rank_id INT(11) NULL');
-
-        if (! Schema::hasColumn('website_staff_applications', 'team_id')) {
-            DB::statement('ALTER TABLE website_staff_applications ADD team_id INT(11) NULL AFTER rank_id');
-        }
-
         if (! Schema::hasColumn('website_staff_applications', 'status')) {
-            DB::statement("ALTER TABLE website_staff_applications ADD status VARCHAR(20) NOT NULL DEFAULT 'pending' AFTER content");
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->string('status', 20)->default('pending')->after('content');
+            });
         }
 
         if (! Schema::hasColumn('website_staff_applications', 'approved_by')) {
-            DB::statement('ALTER TABLE website_staff_applications ADD approved_by INT UNSIGNED NULL AFTER status');
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->integer('approved_by')->nullable()->after('status');
+            });
         }
+
         if (! Schema::hasColumn('website_staff_applications', 'approved_at')) {
-            DB::statement('ALTER TABLE website_staff_applications ADD approved_at TIMESTAMP NULL AFTER approved_by');
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->timestamp('approved_at')->nullable()->after('approved_by');
+            });
         }
+
         if (! Schema::hasColumn('website_staff_applications', 'rejected_by')) {
-            DB::statement('ALTER TABLE website_staff_applications ADD rejected_by INT UNSIGNED NULL AFTER approved_at');
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->integer('rejected_by')->nullable()->after('approved_at');
+            });
         }
+
         if (! Schema::hasColumn('website_staff_applications', 'rejected_at')) {
-            DB::statement('ALTER TABLE website_staff_applications ADD rejected_at TIMESTAMP NULL AFTER rejected_by');
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->timestamp('rejected_at')->nullable()->after('rejected_by');
+            });
         }
 
-        try {
-            DB::statement('ALTER TABLE website_staff_applications
-                ADD CONSTRAINT wsa_team_id_fk
-                FOREIGN KEY (team_id) REFERENCES website_teams(id)
-                ON DELETE SET NULL');
-        } catch (Throwable $e) {
+        if (! $this->foreignKeyExists('wsa_approved_by_fk')) {
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->foreign('approved_by', 'wsa_approved_by_fk')
+                    ->references('id')->on('users')
+                    ->nullOnDelete();
+            });
         }
 
-        try {
-            DB::statement('ALTER TABLE website_staff_applications
-                ADD CONSTRAINT wsa_approved_by_fk
-                FOREIGN KEY (approved_by) REFERENCES users(id)
-                ON DELETE SET NULL');
-        } catch (Throwable $e) {
-        }
-
-        try {
-            DB::statement('ALTER TABLE website_staff_applications
-                ADD CONSTRAINT wsa_rejected_by_fk
-                FOREIGN KEY (rejected_by) REFERENCES users(id)
-                ON DELETE SET NULL');
-        } catch (Throwable $e) {
-        }
-
-        try {
-            DB::statement('CREATE UNIQUE INDEX wsa_user_team_unique
-                ON website_staff_applications (user_id, team_id)');
-        } catch (Throwable $e) {
+        if (! $this->foreignKeyExists('wsa_rejected_by_fk')) {
+            Schema::table('website_staff_applications', function (Blueprint $table) {
+                $table->foreign('rejected_by', 'wsa_rejected_by_fk')
+                    ->references('id')->on('users')
+                    ->nullOnDelete();
+            });
         }
     }
 
     public function down(): void
     {
-        try {
-            DB::statement('DROP INDEX wsa_user_team_unique ON website_staff_applications');
-        } catch (Throwable $e) {
-        }
-
-        foreach (['wsa_team_id_fk', 'wsa_approved_by_fk', 'wsa_rejected_by_fk'] as $fk) {
-            try {
-                DB::statement("ALTER TABLE website_staff_applications DROP FOREIGN KEY {$fk}");
-            } catch (Throwable $e) {
+        foreach (['wsa_approved_by_fk', 'wsa_rejected_by_fk'] as $foreignKey) {
+            if ($this->foreignKeyExists($foreignKey)) {
+                Schema::table('website_staff_applications', function (Blueprint $table) use ($foreignKey) {
+                    $table->dropForeign($foreignKey);
+                });
             }
         }
 
-        if (Schema::hasColumn('website_staff_applications', 'rejected_at')) {
-            DB::statement('ALTER TABLE website_staff_applications DROP COLUMN rejected_at');
-        }
-        if (Schema::hasColumn('website_staff_applications', 'rejected_by')) {
-            DB::statement('ALTER TABLE website_staff_applications DROP COLUMN rejected_by');
-        }
-        if (Schema::hasColumn('website_staff_applications', 'approved_at')) {
-            DB::statement('ALTER TABLE website_staff_applications DROP COLUMN approved_at');
-        }
-        if (Schema::hasColumn('website_staff_applications', 'approved_by')) {
-            DB::statement('ALTER TABLE website_staff_applications DROP COLUMN approved_by');
-        }
-        if (Schema::hasColumn('website_staff_applications', 'status')) {
-            DB::statement('ALTER TABLE website_staff_applications DROP COLUMN status');
-        }
-        if (Schema::hasColumn('website_staff_applications', 'team_id')) {
-            DB::statement('ALTER TABLE website_staff_applications DROP COLUMN team_id');
-        }
+        Schema::table('website_staff_applications', function (Blueprint $table) {
+            $table->dropColumn(['rejected_at', 'rejected_by', 'approved_at', 'approved_by', 'status']);
+        });
+    }
 
-        DB::statement('ALTER TABLE website_staff_applications MODIFY rank_id INT(11) NOT NULL');
+    private function foreignKeyExists(string $constraint): bool
+    {
+        $result = DB::selectOne(<<<'SQL'
+            SELECT COUNT(*) AS aggregate
+            FROM information_schema.table_constraints
+            WHERE constraint_schema = ?
+                AND table_name = 'website_staff_applications'
+                AND constraint_name = ?
+                AND constraint_type = 'FOREIGN KEY'
+            SQL, [DB::getDatabaseName(), $constraint]);
+
+        return (int) ($result->aggregate ?? 0) > 0;
     }
 };

--- a/database/migrations/2026_06_12_000001_add_unique_index_to_used_shop_vouchers.php
+++ b/database/migrations/2026_06_12_000001_add_unique_index_to_used_shop_vouchers.php
@@ -19,6 +19,10 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('website_used_shop_vouchers', function (Blueprint $table) {
+            $table->index('user_id');
+        });
+
+        Schema::table('website_used_shop_vouchers', function (Blueprint $table) {
             $table->dropUnique(['user_id', 'voucher_id']);
         });
     }


### PR DESCRIPTION
## Summary
- preserve existing user, staff, article, and permission data instead of dropping columns during migrations
- add missing rollback implementations and remove destructive permission truncation
- give each migration ownership of only the columns, indexes, and foreign keys it introduces
- fix MariaDB rollback ordering and supporting indexes for foreign-key-backed unique constraints
- replace suppressed staff application schema errors with explicit, type-safe constraints

## Verification
- `php artisan migrate:fresh --force --no-interaction` against MariaDB
- `php artisan migrate:rollback --force --no-interaction` for the complete migration batch
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `vendor/bin/pint --test <changed PHP files>`