### PR TITLE
fix: stop suppressing runtime failures

### DIFF
--- a/app/Console/Commands/ImportBadgeData.php
+++ b/app/Console/Commands/ImportBadgeData.php
@@ -4,11 +4,10 @@ namespace App\Console\Commands;
 
 use App\Models\WebsiteBadge;
 use App\Services\SettingsService;
-use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class ImportBadgeData extends Command
 {
@@ -26,21 +25,25 @@ class ImportBadgeData extends Command
         parent::__construct();
     }
 
-    public function handle(): void
+    public function handle(): int
     {
         $jsonPath = $this->settingsService->getOrDefault('nitro_external_texts_file');
 
         if (! $this->validateJsonFile($jsonPath)) {
-            return;
+            return self::FAILURE;
         }
 
         try {
             $this->processBadgeData($jsonPath);
             $this->info('Badge data imported successfully.');
-        } catch (Exception $e) {
-            Log::error('Failed to import badge data: ' . $e->getMessage());
+        } catch (Throwable $exception) {
+            report($exception);
             $this->error('Failed to import badge data. Check the logs for details.');
+
+            return self::FAILURE;
         }
+
+        return self::SUCCESS;
     }
 
     private function validateJsonFile(?string $jsonPath): bool

--- a/app/Exceptions/HomePurchaseException.php
+++ b/app/Exceptions/HomePurchaseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class HomePurchaseException extends Exception {}

--- a/app/Helpers/helper.php
+++ b/app/Helpers/helper.php
@@ -44,11 +44,7 @@ if (! function_exists('findMigration')) {
 if (! function_exists('columnExists')) {
     function columnExists(string $table, string $column): bool
     {
-        try {
-            return Schema::hasColumn($table, $column);
-        } catch (Throwable) {
-            return false;
-        }
+        return Schema::hasColumn($table, $column);
     }
 }
 

--- a/app/Http/Controllers/Home/HomeController.php
+++ b/app/Http/Controllers/Home/HomeController.php
@@ -11,6 +11,7 @@ use App\Services\Home\HomeService;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Throwable;
 
 class HomeController extends Controller
 {
@@ -52,7 +53,9 @@ class HomeController extends Controller
     {
         try {
             $this->homeService->saveItems($user, $request->validated());
-        } catch (\Throwable) {
+        } catch (Throwable $exception) {
+            report($exception);
+
             return $this->jsonResponse([
                 'message' => __('An error occurred while saving your home.'),
             ], 500);

--- a/app/Http/Controllers/Home/ItemController.php
+++ b/app/Http/Controllers/Home/ItemController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers\Home;
 
+use App\Exceptions\HomePurchaseException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Home\BuyHomeItemRequest;
 use App\Models\User;
 use App\Services\Home\HomeService;
 use Illuminate\Http\JsonResponse;
+use Throwable;
 
 class ItemController extends Controller
 {
@@ -20,10 +22,16 @@ class ItemController extends Controller
 
         try {
             $item = $this->homeService->buyItem($user, $data['item_id'], $data['quantity']);
-        } catch (\Throwable $exception) {
+        } catch (HomePurchaseException $exception) {
             return $this->jsonResponse([
                 'message' => $exception->getMessage(),
             ], 400);
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return $this->jsonResponse([
+                'message' => __('An error occurred while buying this item.'),
+            ], 500);
         }
 
         return $this->jsonResponse([

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,7 @@ use App\Services\SettingsService;
 use App\Services\ViteService;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Vite;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\URL;
@@ -84,13 +85,27 @@ class AppServiceProvider extends ServiceProvider
             $table->paginated([10, 25, 50]);
         });
 
-        $settingsService = app(SettingsService::class);
-        $badgePath = $settingsService->getOrDefault('badge_path_filesystem', '/var/www/gamedata/c_images/album1584');
-        Config::set('filesystems.disks.badges.root', $badgePath);
-
-        $adsPath = $settingsService->getOrDefault('ads_path_filesystem', '/var/www/gamedata/custom');
-        Config::set('filesystems.disks.ads.root', $adsPath);
+        $this->configureFilesystemDisks();
 
         WebsiteDrawBadge::observe(WebsiteDrawBadgeObserver::class);
+    }
+
+    private function configureFilesystemDisks(): void
+    {
+        $badgePath = '/var/www/gamedata/c_images/album1584';
+        $adsPath = '/var/www/gamedata/custom';
+
+        try {
+            $settings = app(SettingsService::class);
+            $badgePath = $settings->getOrDefault('badge_path_filesystem', $badgePath);
+            $adsPath = $settings->getOrDefault('ads_path_filesystem', $adsPath);
+        } catch (QueryException $exception) {
+            if (! $this->app->runningInConsole()) {
+                throw $exception;
+            }
+        }
+
+        Config::set('filesystems.disks.badges.root', $badgePath);
+        Config::set('filesystems.disks.ads.root', $adsPath);
     }
 }

--- a/app/Services/Home/HomeService.php
+++ b/app/Services/Home/HomeService.php
@@ -4,6 +4,7 @@ namespace App\Services\Home;
 
 use App\Emulator\Contracts\CurrencyRepository;
 use App\Enums\HomeItemType;
+use App\Exceptions\HomePurchaseException;
 use App\Models\Home\HomeItem;
 use App\Models\Home\UserHomeItem;
 use App\Models\User;
@@ -14,42 +15,39 @@ class HomeService
 {
     public function __construct(private readonly CurrencyRepository $currencies) {}
 
-    /**
-     * @throws \Exception
-     */
     private function ensurePurchaseIsAllowed(User $user, HomeItem $item, int $quantity, int $totalPrice): void
     {
         if ($user->online) {
-            throw new \Exception(__('You must be offline to buy this item.'));
+            throw new HomePurchaseException(__('You must be offline to buy this item.'));
         }
 
         if (! $item->enabled) {
-            throw new \Exception(__('This item is not available for purchase.'));
+            throw new HomePurchaseException(__('This item is not available for purchase.'));
         }
 
         if ($item->hasExceededPurchaseLimit()) {
-            throw new \Exception(__('This item exceeded the purchase limit.'));
+            throw new HomePurchaseException(__('This item exceeded the purchase limit.'));
         }
 
         if ($item->limit !== null && ($item->total_bought + $quantity) > $item->limit) {
-            throw new \Exception(__("You can't buy more than :max of this item.", [
+            throw new HomePurchaseException(__("You can't buy more than :max of this item.", [
                 'max' => $item->limit - $item->total_bought,
             ]));
         }
 
         if ($totalPrice > $this->currencies->balance($user, $item->currency_type)) {
-            throw new \Exception(__("You don't have enough :currency to buy this item.", [
+            throw new HomePurchaseException(__("You don't have enough :currency to buy this item.", [
                 'currency' => strtolower(__($item->currency_type->name)),
             ]));
         }
 
         if (in_array($item->type, [HomeItemType::Background, HomeItemType::Widget])
             && $user->homeItems()->where('home_item_id', $item->id)->exists()) {
-            throw new \Exception(__('You already have this item in your inventory.'));
+            throw new HomePurchaseException(__('You already have this item in your inventory.'));
         }
 
         if (in_array($item->type, [HomeItemType::Background, HomeItemType::Widget]) && $quantity > 1) {
-            throw new \Exception(__('You can buy this item only once.'));
+            throw new HomePurchaseException(__('You can buy this item only once.'));
         }
     }
 
@@ -71,7 +69,7 @@ class HomeService
             $this->ensurePurchaseIsAllowed($lockedUser, $item, $quantity, $totalPrice);
 
             if (! $this->currencies->deduct($lockedUser, $item->currency_type, $totalPrice)) {
-                throw new \Exception(__('Insufficient balance.'));
+                throw new HomePurchaseException(__('Insufficient balance.'));
             }
 
             $lockedUser->giveHomeItem($item, $quantity);

--- a/app/Services/InstallationService.php
+++ b/app/Services/InstallationService.php
@@ -5,7 +5,6 @@ namespace App\Services;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Throwable;
 
 class InstallationService
 {
@@ -23,29 +22,23 @@ class InstallationService
             return true;
         }
 
-        try {
-            if (! Schema::hasTable('website_installation')) {
-                $this->installationComplete = false;
-
-                return false;
-            }
-
-            // Any completed row counts: the first-visit race can leave
-            // duplicate rows, and completion must not hinge on row order.
-            $isComplete = DB::table('website_installation')->where('completed', true)->exists();
-
-            if ($isComplete) {
-                Cache::rememberForever('app_installed', fn () => true);
-            }
-
-            $this->installationComplete = $isComplete;
-
-            return $isComplete;
-        } catch (Throwable) {
+        if (! Schema::hasTable('website_installation')) {
             $this->installationComplete = false;
 
             return false;
         }
+
+        // Any completed row counts: the first-visit race can leave
+        // duplicate rows, and completion must not hinge on row order.
+        $isComplete = DB::table('website_installation')->where('completed', true)->exists();
+
+        if ($isComplete) {
+            Cache::rememberForever('app_installed', fn () => true);
+        }
+
+        $this->installationComplete = $isComplete;
+
+        return $isComplete;
     }
 
     public static function setComplete(): void

--- a/app/Services/SettingsService.php
+++ b/app/Services/SettingsService.php
@@ -6,7 +6,6 @@ use App\Models\Miscellaneous\WebsiteSetting;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
-use Throwable;
 
 class SettingsService
 {
@@ -44,23 +43,15 @@ class SettingsService
 
     private function isInstallationIncomplete(): bool
     {
-        try {
-            return ! app(InstallationService::class)->isComplete();
-        } catch (Throwable) {
-            return true;
-        }
+        return ! app(InstallationService::class)->isComplete();
     }
 
     private function fetchSettings()
     {
-        try {
-            if (! Schema::hasTable('website_settings')) {
-                return collect();
-            }
-
-            return WebsiteSetting::query()->pluck('value', 'key');
-        } catch (Throwable) {
+        if (! Schema::hasTable('website_settings')) {
             return collect();
         }
+
+        return WebsiteSetting::query()->pluck('value', 'key');
     }
 }


### PR DESCRIPTION
## Summary
- distinguish expected home purchase denials from unexpected infrastructure failures
- report unexpected home save and purchase exceptions without exposing internal messages
- allow installation and settings database failures to reach Laravel's exception handler
- stop treating schema lookup failures as missing columns
- make badge imports report failures and return a nonzero command status

## Verification
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `vendor/bin/pint --test <changed PHP files>`