### PR TITLE
refactor: defer filament side effects until save

### DIFF
--- a/app/Filament/Resources/Atom/Articles/ArticleResource.php
+++ b/app/Filament/Resources/Atom/Articles/ArticleResource.php
@@ -9,7 +9,6 @@ use App\Filament\Resources\Atom\Articles\Pages\ViewArticle;
 use App\Filament\Resources\Atom\Articles\RelationManagers\TagsRelationManager;
 use App\Filament\Traits\TranslatableResource;
 use App\Models\Articles\WebsiteArticle;
-use Exception;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
@@ -102,22 +101,6 @@ class ArticleResource extends Resource
                                 ->onIcon('heroicon-s-check')
                                 ->offIcon('heroicon-s-x-mark')
                                 ->default(true)
-                                ->live()
-                                ->afterStateUpdated(function (string $operation, $state, $record) {
-                                    if ($operation !== 'edit' || is_null($record)) {
-                                        return;
-                                    }
-
-                                    try {
-                                        if ($state) {
-                                            $record->restore();
-                                        } else {
-                                            $record->delete();
-                                        }
-                                    } catch (Exception $e) {
-                                        report($e);
-                                    }
-                                })
                                 ->formatStateUsing(function ($record) {
                                     if (is_null($record)) {
                                         return true;
@@ -187,7 +170,7 @@ class ArticleResource extends Resource
                 ->state(fn ($record) => is_null($record->deleted_at))
                 ->disabled(),
 
-            ToggleColumn::make('allow_comments')
+            ToggleColumn::make('can_comment')
                 ->label(__('filament::resources.columns.allow_comments'))
                 ->onIcon('heroicon-s-check')
                 ->toggleable()

--- a/app/Filament/Resources/Atom/Articles/Pages/CreateArticle.php
+++ b/app/Filament/Resources/Atom/Articles/Pages/CreateArticle.php
@@ -4,8 +4,26 @@ namespace App\Filament\Resources\Atom\Articles\Pages;
 
 use App\Filament\Resources\Atom\Articles\ArticleResource;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 
 class CreateArticle extends CreateRecord
 {
     protected static string $resource = ArticleResource::class;
+
+    protected function handleRecordCreation(array $data): Model
+    {
+        $isVisible = (bool) Arr::pull($data, 'is_visible', true);
+
+        return DB::transaction(function () use ($data, $isVisible): Model {
+            $record = parent::handleRecordCreation($data);
+
+            if (! $isVisible) {
+                $record->delete();
+            }
+
+            return $record;
+        });
+    }
 }

--- a/app/Filament/Resources/Atom/Articles/Pages/EditArticle.php
+++ b/app/Filament/Resources/Atom/Articles/Pages/EditArticle.php
@@ -5,6 +5,9 @@ namespace App\Filament\Resources\Atom\Articles\Pages;
 use App\Filament\Resources\Atom\Articles\ArticleResource;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 
 class EditArticle extends EditRecord
 {
@@ -15,5 +18,22 @@ class EditArticle extends EditRecord
         return [
             DeleteAction::make(),
         ];
+    }
+
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $isVisible = (bool) Arr::pull($data, 'is_visible', true);
+
+        return DB::transaction(function () use ($record, $data, $isVisible): Model {
+            $record = parent::handleRecordUpdate($record, $data);
+
+            if ($isVisible && $record->trashed()) {
+                $record->restore();
+            } elseif (! $isVisible && ! $record->trashed()) {
+                $record->delete();
+            }
+
+            return $record;
+        });
     }
 }

--- a/app/Filament/Resources/User/Users/Pages/EditUser.php
+++ b/app/Filament/Resources/User/Users/Pages/EditUser.php
@@ -15,6 +15,7 @@ use Filament\Resources\Pages\EditRecord;
 use Filament\Support\Exceptions\Halt;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 
 class EditUser extends EditRecord
@@ -61,17 +62,7 @@ class EditUser extends EditRecord
             $this->halt();
         }
 
-        $rcon = app(Rcon::class);
-
-        if (! $user->online) {
-            DB::transaction(function () use ($user, $data) {
-                $this->treatChangedCurrenciesWithoutRcon($user, $data);
-            });
-
-            return;
-        }
-
-        if ($user->online && ! $rcon->isConnected()) {
+        if ($user->online && ! app(Rcon::class)->isConnected()) {
             Notification::make()
                 ->danger()
                 ->title(__('RCON is not enabled!'))
@@ -80,16 +71,30 @@ class EditUser extends EditRecord
 
             $this->halt();
         }
+    }
 
-        DB::transaction(function () use ($user, $data, $rcon) {
-            if ($data['credits'] != $user->credits) {
-                app(SendCurrency::class)->execute($user, CurrencyTypes::Credits, -$user->credits + $data['credits']);
+    protected function handleRecordUpdate(Model $record, array $data): Model
+    {
+        $rcon = app(Rcon::class);
+
+        return DB::transaction(function () use ($record, $data, $rcon): Model {
+            if (! $record->online) {
+                $this->treatChangedCurrenciesWithoutRcon($record, $data);
+
+                return parent::handleRecordUpdate($record, $data);
             }
 
-            $this->checkUsernameChangedPermission($user, $data, $rcon);
-            $this->treatChangedCurrencies($user, $data);
-            $this->treatChangedUserRank($user, $data, $rcon);
-            $this->treatChangedUserMotto($user, $data, $rcon);
+            if ($data['credits'] != $record->credits) {
+                app(SendCurrency::class)->execute($record, CurrencyTypes::Credits, -$record->credits + $data['credits']);
+            }
+
+            $this->checkUsernameChangedPermission($record, $data, $rcon);
+            $this->treatChangedCurrencies($record, $data);
+            $this->treatChangedUserRank($record, $data, $rcon);
+            $this->treatChangedUserMotto($record, $data, $rcon);
+
+            // The emulator persists these fields when the deferred RCON commands run.
+            return parent::handleRecordUpdate($record, Arr::except($data, ['credits', 'rank', 'motto']));
         });
     }
 
@@ -204,8 +209,6 @@ class EditUser extends EditRecord
         }
 
         $rcon->alertUser($user, __('You have been disconnected because your rank has been changed. Please re-enter the hotel.'));
-        sleep(2);
-
         $rcon->disconnectUser($user);
         $rcon->setRank($user, $data['rank']);
     }

--- a/app/Filament/Resources/User/Users/UserResource.php
+++ b/app/Filament/Resources/User/Users/UserResource.php
@@ -194,7 +194,7 @@ class UserResource extends Resource
                                             ->label(__('filament::resources.inputs.rank'))
                                             ->options(Permission::where('id', '<', auth()->user()->rank)->get()->pluck('rank_name', 'id')),
 
-                                        Toggle::make('is_hidden')
+                                        Toggle::make('hidden_staff')
                                             ->label(__('filament::resources.inputs.is_hidden'))
                                             ->default(false),
                                     ])->collapsible()


### PR DESCRIPTION
## Summary
- apply article visibility only when an article is created or saved, inside the record transaction
- defer staff-edit RCON commands until the Filament record update commits
- remove the two-second request-blocking sleep from rank changes
- prevent online credits, rank, and motto from being written twice by Filament and RCON
- align hidden-staff and article-comment controls with their actual database columns

## Verification
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G`
- PHP syntax checks for every changed file
- `vendor/bin/pint --test <changed PHP files>`

## Test gap
- the repository does not currently have Filament Livewire workflow tests; this PR is covered by static checks and the full application regression suite