### PR TITLE
fix: enforce website data constraints

### DIFF
--- a/app/Http/Middleware/VPNCheckerMiddleware.php
+++ b/app/Http/Middleware/VPNCheckerMiddleware.php
@@ -49,7 +49,7 @@ class VPNCheckerMiddleware
         }
 
         if ($this->isThreat($apiResponse)) {
-            WebsiteIpBlacklist::create(['ip_address' => $ip, 'asn' => null]);
+            WebsiteIpBlacklist::firstOrCreate(['ip_address' => $ip], ['asn' => null]);
 
             return $this->restrict();
         }

--- a/app/Livewire/ArticleReactions.php
+++ b/app/Livewire/ArticleReactions.php
@@ -52,19 +52,7 @@ class ArticleReactions extends Component
             return;
         }
 
-        $existingReaction = WebsiteArticleReaction::getReaction($this->article->id, $user->id, $reaction);
-
-        if ($existingReaction) {
-            $existingReaction->update(['active' => ! $existingReaction->active]);
-            $this->dispatch('reactions:loaded');
-
-            return;
-        }
-
-        $this->article->reactions()->create([
-            'user_id' => $user->id,
-            'reaction' => $reaction,
-        ]);
+        WebsiteArticleReaction::toggleFor($this->article, $user, $reaction);
 
         $this->dispatch('reactions:loaded');
     }

--- a/app/Models/Articles/WebsiteArticleReaction.php
+++ b/app/Models/Articles/WebsiteArticleReaction.php
@@ -32,6 +32,7 @@ class WebsiteArticleReaction extends Model
     use HasFactory;
 
     protected $fillable = [
+        'article_id',
         'user_id',
         'reaction',
         'active',
@@ -44,12 +45,21 @@ class WebsiteArticleReaction extends Model
         'article_id',
     ];
 
-    public static function getReaction(int $articleId, int $userId, string $reaction): ?self
+    public static function toggleFor(WebsiteArticle $article, User $user, string $reaction): self
     {
-        return self::where('user_id', $userId)
-            ->where('article_id', $articleId)
-            ->where('reaction', $reaction)
-            ->first();
+        $record = self::query()->firstOrCreate([
+            'article_id' => $article->id,
+            'user_id' => $user->id,
+            'reaction' => $reaction,
+        ], [
+            'active' => true,
+        ]);
+
+        if (! $record->wasRecentlyCreated) {
+            $record->update(['active' => ! $record->active]);
+        }
+
+        return $record;
     }
 
     public function article(): BelongsTo

--- a/app/Services/Articles/ReactionService.php
+++ b/app/Services/Articles/ReactionService.php
@@ -17,20 +17,11 @@ class ReactionService
             return ['success' => false];
         }
 
-        $existingReaction = WebsiteArticleReaction::getReaction($article->id, $user->id, $reaction);
-
-        if ($existingReaction) {
-            $existingReaction->update(['active' => ! $existingReaction->active]);
-        } else {
-            $article->reactions()->create([
-                'user_id' => $user->id,
-                'reaction' => $reaction,
-            ]);
-        }
+        $storedReaction = WebsiteArticleReaction::toggleFor($article, $user, $reaction);
 
         return [
             'success' => true,
-            'added' => $existingReaction->active ?? true,
+            'added' => (bool) $storedReaction->active,
             'username' => $user->username,
         ];
     }

--- a/database/migrations/2026_07_16_030000_enforce_website_data_constraints.php
+++ b/database/migrations/2026_07_16_030000_enforce_website_data_constraints.php
@@ -1,0 +1,143 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->removeOrphans();
+        $this->removeDuplicates('website_article_reactions', ['user_id', 'article_id', 'reaction']);
+        $this->removeDuplicates('website_ip_whitelist', ['ip_address']);
+        $this->removeDuplicates('website_ip_blacklist', ['ip_address']);
+        $this->removeDuplicateTags();
+
+        Schema::table('website_article_reactions', function (Blueprint $table) {
+            $table->integer('user_id')->change();
+        });
+
+        Schema::table('website_article_reactions', function (Blueprint $table) {
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->unique(['user_id', 'article_id', 'reaction'], 'article_reactions_user_article_reaction_unique');
+        });
+
+        Schema::table('website_shop_articles', function (Blueprint $table) {
+            $table->foreign('website_shop_category_id')
+                ->references('id')->on('website_shop_categories')
+                ->nullOnDelete();
+        });
+
+        Schema::table('taggables', function (Blueprint $table) {
+            $table->foreign('tag_id')->references('id')->on('tags')->cascadeOnDelete();
+            $table->unique(['tag_id', 'taggable_type', 'taggable_id'], 'taggables_tag_type_id_unique');
+        });
+
+        Schema::table('website_ip_whitelist', function (Blueprint $table) {
+            $table->unique('ip_address');
+        });
+
+        Schema::table('website_ip_blacklist', function (Blueprint $table) {
+            $table->unique('ip_address');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('website_ip_blacklist', function (Blueprint $table) {
+            $table->dropUnique(['ip_address']);
+        });
+
+        Schema::table('website_ip_whitelist', function (Blueprint $table) {
+            $table->dropUnique(['ip_address']);
+        });
+
+        Schema::table('taggables', function (Blueprint $table) {
+            $table->dropForeign(['tag_id']);
+            $table->dropUnique('taggables_tag_type_id_unique');
+        });
+
+        Schema::table('website_shop_articles', function (Blueprint $table) {
+            $table->dropForeign(['website_shop_category_id']);
+        });
+
+        Schema::table('website_article_reactions', function (Blueprint $table) {
+            $table->dropForeign(['user_id']);
+            $table->dropUnique('article_reactions_user_article_reaction_unique');
+        });
+
+        Schema::table('website_article_reactions', function (Blueprint $table) {
+            $table->unsignedInteger('user_id')->change();
+        });
+    }
+
+    private function removeOrphans(): void
+    {
+        DB::table('website_article_reactions')
+            ->whereNotExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('users')
+                    ->whereColumn('users.id', 'website_article_reactions.user_id');
+            })
+            ->delete();
+
+        DB::table('website_shop_articles')
+            ->whereNotNull('website_shop_category_id')
+            ->whereNotExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('website_shop_categories')
+                    ->whereColumn('website_shop_categories.id', 'website_shop_articles.website_shop_category_id');
+            })
+            ->update(['website_shop_category_id' => null]);
+
+        DB::table('taggables')
+            ->whereNotExists(function ($query) {
+                $query->selectRaw('1')
+                    ->from('tags')
+                    ->whereColumn('tags.id', 'taggables.tag_id');
+            })
+            ->delete();
+    }
+
+    /**
+     * @param  list<string>  $columns
+     */
+    private function removeDuplicates(string $table, array $columns): void
+    {
+        DB::table($table)
+            ->select([...$columns, DB::raw('MAX(id) AS keep_id')])
+            ->groupBy($columns)
+            ->havingRaw('COUNT(*) > 1')
+            ->get()
+            ->each(function (object $duplicate) use ($columns, $table) {
+                $query = DB::table($table);
+
+                foreach ($columns as $column) {
+                    $query->where($column, $duplicate->{$column});
+                }
+
+                $query->where('id', '!=', $duplicate->keep_id)->delete();
+            });
+    }
+
+    private function removeDuplicateTags(): void
+    {
+        DB::table('taggables')
+            ->select('tag_id', 'taggable_type', 'taggable_id')
+            ->groupBy('tag_id', 'taggable_type', 'taggable_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->get()
+            ->each(function (object $duplicate) {
+                $attributes = [
+                    'tag_id' => $duplicate->tag_id,
+                    'taggable_type' => $duplicate->taggable_type,
+                    'taggable_id' => $duplicate->taggable_id,
+                ];
+
+                DB::table('taggables')->where($attributes)->delete();
+                DB::table('taggables')->insert($attributes);
+            });
+    }
+};


### PR DESCRIPTION
## Summary
- remove orphaned and duplicate website records before adding constraints
- enforce reaction, tag, shop-category, and IP-list integrity in MariaDB
- share a race-aware article reaction toggle across Livewire and service callers
- make automatic VPN blacklist inserts idempotent

## Dependency
- stacked on #107 because the reaction write path requires explicit article actors

## Verification
- `php artisan migrate:fresh --force --no-interaction`
- `php artisan migrate:rollback --step=1 --force --no-interaction`
- `php artisan migrate --force --no-interaction`
- `vendor/bin/pest` - 141 tests, 401 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pint --test` on changed PHP files