### PR TITLE
fix: harden browser response security

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,6 +14,7 @@ use App\Http\Middleware\LogViewerMiddleware;
 use App\Http\Middleware\MaintenanceMiddleware;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\SetThemeMiddleware;
 use App\Http\Middleware\TrimStrings;
 use App\Http\Middleware\TrustProxies;
@@ -49,6 +50,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         TrustProxies::class,
+        SecurityHeaders::class,
         HandleCors::class,
         PreventRequestsDuringMaintenance::class,
         ValidatePostSize::class,

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('Content-Security-Policy', "base-uri 'self'; frame-ancestors 'self'");
+        $response->headers->set('Permissions-Policy', 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+
+        if ($request->isSecure() && app()->environment('production')) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000');
+        }
+
+        return $response;
+    }
+}

--- a/resources/themes/atom/views/community/photos.blade.php
+++ b/resources/themes/atom/views/community/photos.blade.php
@@ -17,9 +17,5 @@
         {{ $photos->links() }}
     </div>
 
-    @push('javascript')
-        <script src="https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0/dist/fancybox.umd.js"></script>
-    @endpush
-
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.css" />
+    <x-fancybox-assets />
 </x-app-layout>

--- a/resources/themes/atom/views/index.blade.php
+++ b/resources/themes/atom/views/index.blade.php
@@ -38,9 +38,5 @@
         @endif
     </div>
 
-    @push('javascript')
-        <script src="https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0/dist/fancybox.umd.js"></script>
-    @endpush
-
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.css" />
+    <x-fancybox-assets />
 </x-app-layout>

--- a/resources/themes/atom/views/logo-generator.blade.php
+++ b/resources/themes/atom/views/logo-generator.blade.php
@@ -72,8 +72,12 @@
         </x-content.content-card>
     </div>
 
-    {{-- TODO: Selfhost --}}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.3.3/html2canvas.min.js"></script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
+        integrity="sha384-ZZ1pncU3bQe8y31yfZdMFdSpttDoPmOZg2wguVK9almUodir1PghgT0eY7Mrty8H"
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    ></script>
     <script>
         function logoGenerator() {
             return {
@@ -168,5 +172,4 @@
         }
     </script>
 </x-app-layout>
-
 

--- a/resources/themes/dusk/views/auth/register.blade.php
+++ b/resources/themes/dusk/views/auth/register.blade.php
@@ -156,6 +156,4 @@
         usernameInput.addEventListener('keyup', updateAvatar);
 
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0/dist/fancybox.umd.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.css" />
 </x-app-layout>

--- a/resources/themes/dusk/views/layouts/app.blade.php
+++ b/resources/themes/dusk/views/layouts/app.blade.php
@@ -98,8 +98,7 @@
 
         <x-footer />
 
-        <script src="https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0/dist/fancybox.umd.js"></script>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fancyapps/ui/dist/fancybox.css" />
+        <x-fancybox-assets />
 
         @stack('javascript')
 

--- a/resources/themes/dusk/views/logo-generator.blade.php
+++ b/resources/themes/dusk/views/logo-generator.blade.php
@@ -72,8 +72,12 @@
         </x-content.content-card>
     </div>
 
-    {{-- TODO: Selfhost --}}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.3.3/html2canvas.min.js"></script>
+    <script
+        src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
+        integrity="sha384-ZZ1pncU3bQe8y31yfZdMFdSpttDoPmOZg2wguVK9almUodir1PghgT0eY7Mrty8H"
+        crossorigin="anonymous"
+        referrerpolicy="no-referrer"
+    ></script>
     <script>
         function logoGenerator() {
             return {
@@ -168,5 +172,4 @@
         }
     </script>
 </x-app-layout>
-
 

--- a/resources/views/components/fancybox-assets.blade.php
+++ b/resources/views/components/fancybox-assets.blade.php
@@ -1,0 +1,13 @@
+@once
+    <script
+        src="https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0.31/dist/fancybox.umd.js"
+        integrity="sha384-mfITPNdkUxVtTV4zhg4SDrxOL/aZBoz/p9adHFmaCoLDa43yghU46m5oEkJzLsav"
+        crossorigin="anonymous"
+    ></script>
+    <link
+        rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@fancyapps/ui@4.0.31/dist/fancybox.css"
+        integrity="sha384-kPPlFUTv5pDfb8JmcIDGDPhxzM4ZG0aIQ5/7vANkrD1Z7GR9e3k459LTa7fDCOX/"
+        crossorigin="anonymous"
+    >
+@endonce

--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -8,9 +8,6 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{{ setting('hotel_name') }} - {{ __('Maintenance') }}</title>
 
-    <link rel="stylesheet" href="https://unpkg.com/flowbite@1.5.1/dist/flowbite.min.css"/>
-    <script src="https://unpkg.com/flowbite@1.5.1/dist/flowbite.js"></script>
-
     @vite(['resources/themes/' .  setting('theme') . '/css/app.css', 'resources/themes/' .  setting('theme') . '/js/app.js'], 'build')
 </head>
 

--- a/tests/Feature/Pages/PublicPagesTest.php
+++ b/tests/Feature/Pages/PublicPagesTest.php
@@ -13,6 +13,26 @@ test('public community pages render', function (string $route) {
     'rules' => 'help-center.rules.index',
 ]);
 
+test('public responses include browser security headers', function () {
+    $this->get(route('article.index'))
+        ->assertOk()
+        ->assertHeader('Content-Security-Policy', "base-uri 'self'; frame-ancestors 'self'")
+        ->assertHeader('Permissions-Policy', 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()')
+        ->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin')
+        ->assertHeader('X-Content-Type-Options', 'nosniff')
+        ->assertHeader('X-Frame-Options', 'SAMEORIGIN')
+        ->assertHeaderMissing('Strict-Transport-Security');
+});
+
+test('secure production responses enable transport security', function () {
+    $this->app->detectEnvironment(fn () => 'production');
+
+    $this->withHeader('X-Forwarded-Proto', 'https')
+        ->get(route('article.index'))
+        ->assertOk()
+        ->assertHeader('Strict-Transport-Security', 'max-age=31536000');
+});
+
 test('authenticated community pages render', function (string $route) {
     $this->actingAs(User::factory()->create())
         ->get(route($route))


### PR DESCRIPTION
## Summary
- add global clickjacking, MIME-sniffing, referrer, permissions, and base-URI protections
- enable HSTS only for secure production responses, including trusted-proxy HTTPS
- pin static Fancybox and html2canvas CDN assets and enforce subresource integrity
- remove redundant unpkg Flowbite assets from the maintenance page

## Verification
- `vendor/bin/pest` - 143 tests, 415 assertions
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pint --test` on changed PHP files
- `npx prettier --check` on changed Blade files