### PR TITLE
refactor: type eloquent model contracts

### DIFF
--- a/app/Helpers/helper.php
+++ b/app/Helpers/helper.php
@@ -5,6 +5,13 @@ use App\Services\PermissionsService;
 use App\Services\SettingsService;
 
 if (! function_exists('setting')) {
+    /**
+     * @template TDefault
+     *
+     * @param  TDefault  $default
+     *
+     * @return string|TDefault
+     */
     function setting(string $key, mixed $default = null): mixed
     {
         return app(SettingsService::class)->getOrDefault($key, $default);

--- a/app/Http/Controllers/User/ReferralController.php
+++ b/app/Http/Controllers/User/ReferralController.php
@@ -13,16 +13,18 @@ class ReferralController extends Controller
     public function __invoke(SendCurrency $sendCurrency): RedirectResponse
     {
         $user = Auth::user();
-        if (! $user->referrals || $user->referrals->referrals_total < setting('referrals_needed')) {
+        $referralsNeeded = (int) setting('referrals_needed', 5);
+
+        if (! $user->referrals || $user->referrals->referrals_total < $referralsNeeded) {
             return redirect()->back()->withErrors([
                 'message' => __('You do not have enough referrals to claim your reward'),
             ]);
         }
 
         // Decrease the total amount of referrals with the amount needed to claim reward
-        $user->referrals->decrement('referrals_total', setting('referrals_needed'));
+        $user->referrals->decrement('referrals_total', $referralsNeeded);
 
-        $sendCurrency->execute($user, CurrencyTypes::Diamonds, (int) setting('referral_reward_amount'));
+        $sendCurrency->execute($user, CurrencyTypes::Diamonds, (int) setting('referral_reward_amount', 30));
 
         // Log the claim
         $user->claimedReferralLog()->create([

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -8,6 +8,7 @@ use App\Models\Articles\WebsiteArticleReaction;
 use Auth;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -54,6 +55,7 @@ use Str;
  */
 class Article extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
@@ -89,6 +91,7 @@ class Article extends Model
         );
     }
 
+    /** @return Builder<Article> */
     public static function fromIdAndSlug(string $id, string $slug, bool $withDefaultRelationships = true): Builder
     {
         return Article::valid()
@@ -113,6 +116,7 @@ class Article extends Model
         return $article;
     }
 
+    /** @return Builder<Article> */
     public static function forIndex(int $limit): Builder
     {
         return Article::valid()
@@ -122,11 +126,13 @@ class Article extends Model
             ->latest();
     }
 
+    /** @param Builder<static> $query */
     public function scopeValid(Builder $query): void
     {
         $query->whereVisible(true);
     }
 
+    /** @param Builder<static> $query */
     public function scopeDefaultRelationships(Builder $query): void
     {
         $query->with([
@@ -136,21 +142,25 @@ class Article extends Model
         ]);
     }
 
+    /** @return HasMany<WebsiteArticleComment, $this> */
     public function comments(): HasMany
     {
         return $this->hasMany(WebsiteArticleComment::class);
     }
 
+    /** @return HasMany<WebsiteArticleReaction, $this> */
     public function reactions(): HasMany
     {
         return $this->hasMany(WebsiteArticleReaction::class);
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return MorphToMany<Tag, $this> */
     public function tags(): MorphToMany
     {
         return $this->morphToMany(Tag::class, 'taggable');

--- a/app/Models/Articles/Tag.php
+++ b/app/Models/Articles/Tag.php
@@ -3,8 +3,10 @@
 namespace App\Models\Articles;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -29,11 +31,13 @@ use Illuminate\Support\Carbon;
  */
 class Tag extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
 
-    public function websiteArticles()
+    /** @return MorphToMany<WebsiteArticle, $this> */
+    public function websiteArticles(): MorphToMany
     {
         return $this->morphedByMany(WebsiteArticle::class, 'taggable');
     }

--- a/app/Models/Articles/WebsiteArticle.php
+++ b/app/Models/Articles/WebsiteArticle.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
@@ -76,17 +77,20 @@ class WebsiteArticle extends Model
             ->allowDuplicateSlugs();
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return HasMany<WebsiteArticleReaction, $this> */
     public function reactions(): HasMany
     {
         return $this->hasMany(WebsiteArticleReaction::class, 'article_id')
             ->whereActive(true);
     }
 
+    /** @return HasMany<WebsiteArticleComment, $this> */
     public function comments(): HasMany
     {
         return $this->hasMany(WebsiteArticleComment::class, 'article_id');
@@ -108,7 +112,8 @@ class WebsiteArticle extends Model
         });
     }
 
-    public function tags()
+    /** @return MorphToMany<Tag, $this> */
+    public function tags(): MorphToMany
     {
         return $this->morphToMany(Tag::class, 'taggable');
     }

--- a/app/Models/Articles/WebsiteArticleComment.php
+++ b/app/Models/Articles/WebsiteArticleComment.php
@@ -34,11 +34,13 @@ class WebsiteArticleComment extends Model
 {
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
+    /** @return BelongsTo<WebsiteArticle, $this> */
     public function article(): BelongsTo
     {
         return $this->belongsTo(WebsiteArticle::class, 'article_id');
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Articles/WebsiteArticleReaction.php
+++ b/app/Models/Articles/WebsiteArticleReaction.php
@@ -3,6 +3,7 @@
 namespace App\Models\Articles;
 
 use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -29,6 +30,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class WebsiteArticleReaction extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
@@ -57,11 +59,13 @@ class WebsiteArticleReaction extends Model
         });
     }
 
+    /** @return BelongsTo<WebsiteArticle, $this> */
     public function article(): BelongsTo
     {
         return $this->belongsTo(WebsiteArticle::class, 'article_id');
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/ChatlogPrivate.php
+++ b/app/Models/ChatlogPrivate.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -28,6 +29,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class ChatlogPrivate extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'chatlogs_private';
@@ -36,11 +38,13 @@ class ChatlogPrivate extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function sender(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_from_id');
     }
 
+    /** @return BelongsTo<User, $this> */
     public function receiver(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_to_id');

--- a/app/Models/ChatlogRoom.php
+++ b/app/Models/ChatlogRoom.php
@@ -3,8 +3,10 @@
 namespace App\Models;
 
 use App\Models\Game\Room;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int $room_id
@@ -29,6 +31,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ChatlogRoom extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'chatlogs_room';
@@ -39,17 +42,20 @@ class ChatlogRoom extends Model
 
     protected $primaryKey = 'timestamp';
 
-    public function room()
+    /** @return BelongsTo<Room, $this> */
+    public function room(): BelongsTo
     {
         return $this->belongsTo(Room::class);
     }
 
-    public function sender()
+    /** @return BelongsTo<User, $this> */
+    public function sender(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_from_id');
     }
 
-    public function receiver()
+    /** @return BelongsTo<User, $this> */
+    public function receiver(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_to_id');
     }

--- a/app/Models/CommandLog.php
+++ b/app/Models/CommandLog.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -28,6 +29,7 @@ use Illuminate\Support\Carbon;
  */
 class CommandLog extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'commandlogs';
@@ -42,6 +44,7 @@ class CommandLog extends Model
         'timestamp' => 'datetime',
     ];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Community/RareValue/WebsiteRareValue.php
+++ b/app/Models/Community/RareValue/WebsiteRareValue.php
@@ -48,11 +48,13 @@ class WebsiteRareValue extends Model
         ];
     }
 
+    /** @return BelongsTo<WebsiteRareValueCategory, $this> */
     public function category(): BelongsTo
     {
         return $this->belongsTo(WebsiteRareValueCategory::class, 'category_id');
     }
 
+    /** @return BelongsTo<CatalogItem, $this> */
     public function item(): BelongsTo
     {
         return $this->belongsTo(CatalogItem::class, 'item_id', 'item_ids');

--- a/app/Models/Community/RareValue/WebsiteRareValueCategory.php
+++ b/app/Models/Community/RareValue/WebsiteRareValueCategory.php
@@ -33,6 +33,7 @@ class WebsiteRareValueCategory extends Model
 {
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
+    /** @return HasMany<WebsiteRareValue, $this> */
     public function furniture(): HasMany
     {
         return $this->hasMany(WebsiteRareValue::class, 'category_id');

--- a/app/Models/Community/Staff/WebsiteOpenPosition.php
+++ b/app/Models/Community/Staff/WebsiteOpenPosition.php
@@ -4,7 +4,9 @@ namespace App\Models\Community\Staff;
 
 use App\Models\Community\Teams\WebsiteTeam;
 use App\Models\Game\Permission;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -44,6 +46,7 @@ use Illuminate\Support\Carbon;
  */
 class WebsiteOpenPosition extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'website_open_positions';
@@ -75,22 +78,30 @@ class WebsiteOpenPosition extends Model
         });
     }
 
+    /** @return BelongsTo<Permission, $this> */
     public function permission(): BelongsTo
     {
         return $this->belongsTo(Permission::class, 'permission_id');
     }
 
+    /** @return BelongsTo<WebsiteTeam, $this> */
     public function team(): BelongsTo
     {
         return $this->belongsTo(WebsiteTeam::class, 'team_id');
     }
 
+    /** @return HasMany<WebsiteStaffApplications, $this> */
     public function applications(): HasMany
     {
         return $this->hasMany(WebsiteStaffApplications::class, 'rank_id', 'permission_id');
     }
 
-    public function scopeCanApply($query)
+    /**
+     * @param  Builder<static>  $query
+     *
+     * @return Builder<static>
+     */
+    public function scopeCanApply(Builder $query): Builder
     {
         return $query->where('apply_from', '<=', now())->where('apply_to', '>', now());
     }

--- a/app/Models/Community/Staff/WebsiteStaffApplications.php
+++ b/app/Models/Community/Staff/WebsiteStaffApplications.php
@@ -67,26 +67,31 @@ class WebsiteStaffApplications extends Model
         'rejected_at' => 'datetime',
     ];
 
+    /** @return BelongsTo<User, $this> */
     public function approver(): BelongsTo
     {
         return $this->belongsTo(User::class, 'approved_by');
     }
 
+    /** @return BelongsTo<User, $this> */
     public function rejector(): BelongsTo
     {
         return $this->belongsTo(User::class, 'rejected_by');
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    /** @return BelongsTo<Permission, $this> */
     public function rank(): BelongsTo
     {
         return $this->belongsTo(Permission::class, 'rank_id');
     }
 
+    /** @return BelongsTo<WebsiteTeam, $this> */
     public function team(): BelongsTo
     {
         return $this->belongsTo(WebsiteTeam::class, 'team_id');

--- a/app/Models/Community/Staff/WebsiteTeam.php
+++ b/app/Models/Community/Staff/WebsiteTeam.php
@@ -40,6 +40,7 @@ class WebsiteTeam extends Model
 {
     protected $guarded = [];
 
+    /** @return HasMany<User, $this> */
     public function users(): HasMany
     {
         return $this->hasMany(User::class, 'team_id', 'id');

--- a/app/Models/Community/Teams/WebsiteTeam.php
+++ b/app/Models/Community/Teams/WebsiteTeam.php
@@ -4,6 +4,7 @@ namespace App\Models\Community\Teams;
 
 use App\Models\Community\Staff\WebsiteOpenPosition;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -55,17 +56,24 @@ class WebsiteTeam extends Model
         'staff_background',
     ];
 
+    /** @return HasMany<User, $this> */
     public function users(): HasMany
     {
         return $this->hasMany(User::class, 'team_id', 'id');
     }
 
+    /** @return HasMany<WebsiteOpenPosition, $this> */
     public function openPositions(): HasMany
     {
         return $this->hasMany(WebsiteOpenPosition::class, 'team_id', 'id');
     }
 
-    public function scopeVisible($query)
+    /**
+     * @param  Builder<static>  $query
+     *
+     * @return Builder<static>
+     */
+    public function scopeVisible(Builder $query): Builder
     {
         return $query->where('hidden_rank', false);
     }

--- a/app/Models/EmulatorText.php
+++ b/app/Models/EmulatorText.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -19,6 +20,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class EmulatorText extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];

--- a/app/Models/Game/Furniture/CatalogItem.php
+++ b/app/Models/Game/Furniture/CatalogItem.php
@@ -56,6 +56,7 @@ class CatalogItem extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<ItemBase, $this> */
     public function itemBase(): BelongsTo
     {
         return $this->belongsTo(ItemBase::class, 'item_ids', 'id');

--- a/app/Models/Game/Furniture/CatalogPage.php
+++ b/app/Models/Game/Furniture/CatalogPage.php
@@ -68,6 +68,7 @@ class CatalogPage extends Model
 
     public $timestamps = false;
 
+    /** @return HasMany<CatalogItem, $this> */
     public function catalogItems(): HasMany
     {
         return $this->hasMany(CatalogItem::class, 'page_id');

--- a/app/Models/Game/Furniture/Item.php
+++ b/app/Models/Game/Furniture/Item.php
@@ -48,16 +48,19 @@ class Item extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<Room, $this> */
     public function room(): BelongsTo
     {
         return $this->belongsTo(Room::class);
     }
 
+    /** @return BelongsTo<ItemBase, $this> */
     public function itemBase(): BelongsTo
     {
         return $this->belongsTo(ItemBase::class, 'item_id');

--- a/app/Models/Game/Furniture/ItemBase.php
+++ b/app/Models/Game/Furniture/ItemBase.php
@@ -83,12 +83,17 @@ class ItemBase extends Model
         return sprintf('%s/%s_icon.png', setting('furniture_icons_path'), $this->item_name);
     }
 
+    /** @return HasMany<CatalogItem, $this> */
     public function catalogItems(): HasMany
     {
         return $this->hasMany(CatalogItem::class, 'item_ids', 'id');
     }
 
-    /** Rows in `items` - one record per placed/owned piece of this base item. */
+    /**
+     * Rows in `items` - one record per placed/owned piece of this base item.
+     *
+     * @return HasMany<Item, $this>
+     */
     public function instances(): HasMany
     {
         return $this->hasMany(Item::class, 'item_id', 'id');

--- a/app/Models/Game/Guild/Guild.php
+++ b/app/Models/Game/Guild/Guild.php
@@ -54,6 +54,7 @@ class Guild extends Model
 
     public $timestamps = false;
 
+    /** @return HasMany<GuildMember, $this> */
     public function members(): HasMany
     {
         return $this->hasMany(GuildMember::class);

--- a/app/Models/Game/Guild/GuildMember.php
+++ b/app/Models/Game/Guild/GuildMember.php
@@ -34,6 +34,7 @@ class GuildMember extends Model
 
     public $timestamps = false;
 
+    /** @return HasMany<Guild, $this> */
     public function guilds(): HasMany
     {
         return $this->hasMany(Guild::class);

--- a/app/Models/Game/Permission.php
+++ b/app/Models/Game/Permission.php
@@ -447,11 +447,13 @@ class Permission extends Model implements HasBadge
 
     protected $guarded = ['id'];
 
+    /** @return HasMany<User, $this> */
     public function users(): HasMany
     {
         return $this->hasMany(User::class, 'rank', 'id');
     }
 
+    /** @return HasMany<WebsiteStaffApplications, $this> */
     public function staffApplications(): HasMany
     {
         return $this->hasMany(WebsiteStaffApplications::class, 'rank_id');

--- a/app/Models/Game/Player/MessengerFriendship.php
+++ b/app/Models/Game/Player/MessengerFriendship.php
@@ -29,6 +29,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class MessengerFriendship extends Model
 {
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_two_id', 'id');

--- a/app/Models/Game/Player/UserBadge.php
+++ b/app/Models/Game/Player/UserBadge.php
@@ -33,6 +33,7 @@ class UserBadge extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');

--- a/app/Models/Game/Player/UserCurrency.php
+++ b/app/Models/Game/Player/UserCurrency.php
@@ -31,6 +31,7 @@ class UserCurrency extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id', 'id');

--- a/app/Models/Game/Player/UserSetting.php
+++ b/app/Models/Game/Player/UserSetting.php
@@ -127,6 +127,7 @@ class UserSetting extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Game/Player/UserSubscription.php
+++ b/app/Models/Game/Player/UserSubscription.php
@@ -33,6 +33,7 @@ class UserSubscription extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Game/Room.php
+++ b/app/Models/Game/Room.php
@@ -110,11 +110,13 @@ class Room extends Model
 {
     protected $guarded = ['id'];
 
+    /** @return HasOne<Guild, $this> */
     public function guild(): HasOne
     {
         return $this->hasOne(Guild::class, 'room_id');
     }
 
+    /** @return BelongsTo<User, $this> */
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'owner_id', 'id');

--- a/app/Models/Help/WebsiteHelpCenterTicket.php
+++ b/app/Models/Help/WebsiteHelpCenterTicket.php
@@ -44,43 +44,46 @@ class WebsiteHelpCenterTicket extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<WebsiteHelpCenterCategory, $this> */
     public function category(): BelongsTo
     {
         return $this->belongsTo(WebsiteHelpCenterCategory::class);
     }
 
+    /** @return HasMany<WebsiteHelpCenterTicketReply, $this> */
     public function replies(): HasMany
     {
         return $this->hasMany(WebsiteHelpCenterTicketReply::class, 'ticket_id');
     }
 
-    public function canDeleteTicket()
+    public function canDeleteTicket(): bool
     {
         return $this->user_id === Auth::id() || hasPermission('delete_website_tickets');
     }
 
-    public function canManageTicket()
+    public function canManageTicket(): bool
     {
         return $this->user_id === Auth::id() || hasPermission('manage_website_tickets');
     }
 
-    public function canCloseTicket()
+    public function canCloseTicket(): bool
     {
         return $this->user_id === Auth::id() || hasPermission('manage_website_tickets');
     }
 
-    public function isOpen()
+    public function isOpen(): bool
     {
         return $this->open || hasPermission('manage_website_tickets');
     }
 
-    public function getContentAttribute($value)
+    public function getContentAttribute(string $value): string
     {
-        return Purify::clean($value);
+        return (string) Purify::clean($value);
     }
 }

--- a/app/Models/Help/WebsiteHelpCenterTicketReply.php
+++ b/app/Models/Help/WebsiteHelpCenterTicketReply.php
@@ -35,23 +35,25 @@ class WebsiteHelpCenterTicketReply extends Model
 {
     protected $guarded = ['id'];
 
+    /** @return BelongsTo<WebsiteHelpCenterTicket, $this> */
     public function ticket(): BelongsTo
     {
         return $this->belongsTo(WebsiteHelpCenterTicket::class, 'ticket_id');
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    public function canDeleteReply()
+    public function canDeleteReply(): bool
     {
         return $this->user_id === Auth::id() || hasPermission('delete_website_ticket_replies');
     }
 
-    public function getContentAttribute($value)
+    public function getContentAttribute(string $value): string
     {
-        return Purify::clean($value);
+        return (string) Purify::clean($value);
     }
 }

--- a/app/Models/Help/WebsiteRule.php
+++ b/app/Models/Help/WebsiteRule.php
@@ -31,6 +31,7 @@ class WebsiteRule extends Model
 {
     protected $guarded = [];
 
+    /** @return BelongsTo<WebsiteRuleCategory, $this> */
     public function category(): BelongsTo
     {
         return $this->belongsTo(WebsiteRuleCategory::class, 'category_id');

--- a/app/Models/Help/WebsiteRuleCategory.php
+++ b/app/Models/Help/WebsiteRuleCategory.php
@@ -33,6 +33,7 @@ class WebsiteRuleCategory extends Model
 {
     protected $guarded = [];
 
+    /** @return HasMany<WebsiteRule, $this> */
     public function rules(): HasMany
     {
         return $this->hasMany(WebsiteRule::class, 'category_id');

--- a/app/Models/Home/HomeCategory.php
+++ b/app/Models/Home/HomeCategory.php
@@ -2,16 +2,19 @@
 
 namespace App\Models\Home;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class HomeCategory extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
 
+    /** @return HasMany<HomeItem, $this> */
     public function homeItems(): HasMany
     {
         return $this->hasMany(HomeItem::class);

--- a/app/Models/Home/HomeItem.php
+++ b/app/Models/Home/HomeItem.php
@@ -5,6 +5,7 @@ namespace App\Models\Home;
 use App\Enums\CurrencyTypes;
 use App\Enums\HomeItemType;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class HomeItem extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
@@ -40,16 +42,19 @@ class HomeItem extends Model
         ];
     }
 
+    /** @return BelongsTo<HomeCategory, $this> */
     public function homeCategory(): BelongsTo
     {
         return $this->belongsTo(HomeCategory::class);
     }
 
+    /** @return HasMany<UserHomeItem, $this> */
     public function userHomeItems(): HasMany
     {
         return $this->hasMany(UserHomeItem::class, 'home_item_id');
     }
 
+    /** @param Builder<static> $query */
     public function scopeEnabled(Builder $query): void
     {
         $query->where('enabled', true);

--- a/app/Models/Home/UserHomeItem.php
+++ b/app/Models/Home/UserHomeItem.php
@@ -6,6 +6,7 @@ use App\Enums\HomeItemType;
 use App\Models\User;
 use App\Services\Home\HomeService;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -21,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class UserHomeItem extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
@@ -50,6 +52,7 @@ class UserHomeItem extends Model
         return $this->belongsTo(HomeItem::class);
     }
 
+    /** @param Builder<static> $query */
     public function scopeDefaultRelationships(Builder $query, bool $completeLoading = false): void
     {
         $relation = $completeLoading ? 'homeItem' : 'homeItem:id,type,name,image';

--- a/app/Models/Home/UserHomeMessage.php
+++ b/app/Models/Home/UserHomeMessage.php
@@ -5,31 +5,37 @@ namespace App\Models\Home;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class UserHomeMessage extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<User, $this> */
     public function recipientUser(): BelongsTo
     {
         return $this->belongsTo(User::class, 'recipient_user_id');
     }
 
+    /** @param Builder<static> $query */
     public function scopeDefaultUserData(Builder $query): void
     {
         $query->with('user:id,username,look,online');
     }
 
+    /** @return Attribute<string, never> */
     public function renderedContent(): Attribute
     {
         return new Attribute(

--- a/app/Models/Home/UserHomeRating.php
+++ b/app/Models/Home/UserHomeRating.php
@@ -3,6 +3,7 @@
 namespace App\Models\Home;
 
 use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,17 +17,20 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class UserHomeRating extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<User, $this> */
     public function ratedUser(): BelongsTo
     {
         return $this->belongsTo(User::class, 'rated_user_id');

--- a/app/Models/ItemDefinition.php
+++ b/app/Models/ItemDefinition.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -69,6 +70,7 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ItemDefinition extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $table = 'items_base';

--- a/app/Models/Miscellaneous/CameraWeb.php
+++ b/app/Models/Miscellaneous/CameraWeb.php
@@ -46,7 +46,8 @@ class CameraWeb extends Model
         'timestamp' => 'datetime',
     ];
 
-    public function scopePeriod(Builder $query, $period): void
+    /** @param Builder<static> $query */
+    public function scopePeriod(Builder $query, string $period): void
     {
         if ($period == 'today') {
             $query->where('timestamp', '>=', Carbon::today()->timestamp);
@@ -61,16 +62,19 @@ class CameraWeb extends Model
         }
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<Room, $this> */
     public function room(): BelongsTo
     {
         return $this->belongsTo(Room::class);
     }
 
+    /** @return Attribute<string, never> */
     public function formattedDate(): Attribute
     {
         return new Attribute(

--- a/app/Models/Miscellaneous/WebsiteBetaCode.php
+++ b/app/Models/Miscellaneous/WebsiteBetaCode.php
@@ -30,6 +30,7 @@ class WebsiteBetaCode extends Model
 {
     protected $guarded = ['id'];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Miscellaneous/WebsiteMaintenanceTask.php
+++ b/app/Models/Miscellaneous/WebsiteMaintenanceTask.php
@@ -32,6 +32,7 @@ class WebsiteMaintenanceTask extends Model
 {
     protected $guarded = [];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/PasswordResetToken.php
+++ b/app/Models/PasswordResetToken.php
@@ -53,6 +53,7 @@ class PasswordResetToken extends Model
             ->isPast();
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'email', 'mail');

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Models\Game\Furniture\Item;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -111,17 +112,20 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class Room extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $guarded = [];
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'owner_id');
     }
 
+    /** @return HasMany<Item, $this> */
     public function items(): HasMany
     {
         return $this->hasMany(Item::class, 'room_id');

--- a/app/Models/Shop/WebsitePaypalTransaction.php
+++ b/app/Models/Shop/WebsitePaypalTransaction.php
@@ -38,6 +38,7 @@ class WebsitePaypalTransaction extends Model
 {
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Shop/WebsiteShopArticle.php
+++ b/app/Models/Shop/WebsiteShopArticle.php
@@ -59,6 +59,7 @@ class WebsiteShopArticle extends Model
 {
     protected $guarded = ['id'];
 
+    /** @return Collection<int, ItemBase> */
     public function furniItems(): Collection
     {
         if (! $this->furniture) {
@@ -71,11 +72,13 @@ class WebsiteShopArticle extends Model
         return ItemBase::whereIn('id', $furnitureIds)->get();
     }
 
+    /** @return HasOne<Permission, $this> */
     public function rank(): HasOne
     {
         return $this->hasOne(Permission::class, 'id', 'give_rank');
     }
 
+    /** @return HasMany<WebsiteShopArticleFeature, $this> */
     public function features(): HasMany
     {
         return $this->hasMany(WebsiteShopArticleFeature::class, 'article_id', 'id');

--- a/app/Models/Shop/WebsiteShopArticleFeature.php
+++ b/app/Models/Shop/WebsiteShopArticleFeature.php
@@ -29,6 +29,7 @@ class WebsiteShopArticleFeature extends Model
 {
     protected $guarded = ['id'];
 
+    /** @return BelongsTo<WebsiteShopArticle, $this> */
     public function article(): BelongsTo
     {
         return $this->belongsTo(WebsiteShopArticle::class, 'article_id', 'id');

--- a/app/Models/Shop/WebsiteShopCategory.php
+++ b/app/Models/Shop/WebsiteShopCategory.php
@@ -33,11 +33,13 @@ class WebsiteShopCategory extends Model
 {
     protected $guarded = [];
 
+    /** @return HasMany<WebsiteShopArticle, $this> */
     public function articles(): HasMany
     {
         return $this->hasMany(WebsiteShopArticle::class);
     }
 
+    /** @return HasMany<WebsiteShopPackage, $this> */
     public function packages(): HasMany
     {
         return $this->hasMany(WebsiteShopPackage::class);

--- a/app/Models/Shop/WebsiteUsedShopVoucher.php
+++ b/app/Models/Shop/WebsiteUsedShopVoucher.php
@@ -2,9 +2,7 @@
 
 namespace App\Models\Shop;
 
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -13,8 +11,6 @@ use Illuminate\Support\Carbon;
  * @property int $voucher_id
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
- * @property-read Collection<int, WebsiteUsedShopVoucher> $used
- * @property-read int|null $used_count
  *
  * @method static \Illuminate\Database\Eloquent\Builder<static>|WebsiteUsedShopVoucher newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|WebsiteUsedShopVoucher newQuery()
@@ -30,9 +26,4 @@ use Illuminate\Support\Carbon;
 class WebsiteUsedShopVoucher extends Model
 {
     protected $guarded = ['id'];
-
-    public function used(): HasMany
-    {
-        return $this->hasMany(WebsiteUsedShopVoucher::class, 'voucher_id');
-    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -26,6 +26,7 @@ use App\Models\User\Ban;
 use App\Models\User\ClaimedReferralLog;
 use App\Models\User\Referral;
 use App\Models\User\UserReferral;
+use Database\Factories\UserFactory;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasName;
 use Filament\Panel;
@@ -174,7 +175,12 @@ use Spatie\Activitylog\Traits\LogsActivity;
  */
 class User extends Authenticatable implements FilamentUser, HasName
 {
-    use HasApiTokens, HasFactory, HasHome, LogsActivity, Notifiable, TwoFactorAuthenticatable;
+    use HasApiTokens;
+
+    /** @use HasFactory<UserFactory> */
+    use HasFactory;
+
+    use HasHome, LogsActivity, Notifiable, TwoFactorAuthenticatable;
 
     public $timestamps = false;
 
@@ -231,6 +237,7 @@ class User extends Authenticatable implements FilamentUser, HasName
         return $this->hasMany(UserCurrency::class, 'user_id');
     }
 
+    /** @return HasMany<Session, $this> */
     public function sessions(): HasMany
     {
         return $this->hasMany(Session::class);
@@ -243,26 +250,31 @@ class User extends Authenticatable implements FilamentUser, HasName
         return $type === null ? 0 : app(CurrencyRepository::class)->balance($this, $type);
     }
 
+    /** @return HasOne<Permission, $this> */
     public function permission(): HasOne
     {
         return $this->hasOne(Permission::class, 'id', 'rank');
     }
 
+    /** @return HasMany<WebsiteArticle, $this> */
     public function articles(): HasMany
     {
         return $this->hasMany(WebsiteArticle::class);
     }
 
+    /** @return HasOne<UserReferral, $this> */
     public function referrals(): HasOne
     {
         return $this->hasOne(UserReferral::class);
     }
 
+    /** @return HasMany<Referral, $this> */
     public function userReferrals(): HasMany
     {
         return $this->hasMany(Referral::class);
     }
 
+    /** @return HasMany<ClaimedReferralLog, $this> */
     public function claimedReferralLog(): HasMany
     {
         return $this->hasMany(ClaimedReferralLog::class);
@@ -276,11 +288,13 @@ class User extends Authenticatable implements FilamentUser, HasName
         return $this->hasMany(UserBadge::class);
     }
 
+    /** @return HasMany<Room, $this> */
     public function rooms(): HasMany
     {
         return $this->hasMany(Room::class, 'owner_id');
     }
 
+    /** @return HasMany<MessengerFriendship, $this> */
     public function friends(): HasMany
     {
         return $this->hasMany(MessengerFriendship::class, 'user_one_id');
@@ -290,14 +304,16 @@ class User extends Authenticatable implements FilamentUser, HasName
     {
         $referrals = $this->referrals?->referrals_total ?? 0;
 
-        return setting('referrals_needed') - $referrals;
+        return (int) setting('referrals_needed', 5) - $referrals;
     }
 
+    /** @return HasOne<Ban, $this> */
     public function ban(): HasOne
     {
         return $this->hasOne(Ban::class, 'user_id')->where('ban_expire', '>', time())->whereIn('type', ['account', 'super']);
     }
 
+    /** @return HasOne<UserSetting, $this> */
     public function settings(): HasOne
     {
         return $this->hasOne(UserSetting::class);
@@ -308,7 +324,7 @@ class User extends Authenticatable implements FilamentUser, HasName
         $maxAttempts = 5;
 
         for ($i = 0; $i < $maxAttempts; $i++) {
-            $sso = sprintf('%s-%s', Str::replace(' ', '', setting('hotel_name')), Str::uuid());
+            $sso = sprintf('%s-%s', Str::replace(' ', '', setting('hotel_name', 'Atom')), Str::uuid());
 
             if (! User::where('auth_ticket', $sso)->exists()) {
                 $this->update(['auth_ticket' => $sso]);
@@ -320,26 +336,31 @@ class User extends Authenticatable implements FilamentUser, HasName
         throw new \RuntimeException('Failed to generate unique SSO ticket after ' . $maxAttempts . ' attempts.');
     }
 
+    /** @return HasOne<WebsiteBetaCode, $this> */
     public function betaCode(): HasOne
     {
         return $this->hasOne(WebsiteBetaCode::class);
     }
 
+    /** @return BelongsTo<WebsiteTeam, $this> */
     public function team(): BelongsTo
     {
         return $this->belongsTo(WebsiteTeam::class, 'team_id');
     }
 
+    /** @return HasMany<WebsiteStaffApplications, $this> */
     public function applications(): HasMany
     {
         return $this->hasMany(WebsiteStaffApplications::class, 'user_id');
     }
 
+    /** @return HasOne<UserSubscription, $this> */
     public function hcSubscription(): HasOne
     {
         return $this->hasOne(UserSubscription::class);
     }
 
+    /** @return HasMany<WebsiteArticleComment, $this> */
     public function articleComments(): HasMany
     {
         return $this->hasMany(WebsiteArticleComment::class);
@@ -353,36 +374,43 @@ class User extends Authenticatable implements FilamentUser, HasName
         return $this->hasMany(WebsitePaypalTransaction::class);
     }
 
+    /** @return HasMany<WebsiteUsedShopVoucher, $this> */
     public function usedShopVouchers(): HasMany
     {
         return $this->hasMany(WebsiteUsedShopVoucher::class);
     }
 
+    /** @return HasMany<Item, $this> */
     public function items(): HasMany
     {
         return $this->hasMany(Item::class, 'user_id');
     }
 
+    /** @return HasMany<WebsiteHelpCenterTicket, $this> */
     public function tickets(): HasMany
     {
         return $this->hasMany(WebsiteHelpCenterTicket::class);
     }
 
+    /** @return HasMany<CameraWeb, $this> */
     public function photos(): HasMany
     {
         return $this->hasMany(CameraWeb::class);
     }
 
+    /** @return HasMany<ChatlogRoom, $this> */
     public function chatLogs(): HasMany
     {
         return $this->hasMany(ChatlogRoom::class, 'user_from_id');
     }
 
+    /** @return HasMany<ChatlogPrivate, $this> */
     public function chatLogsPrivate(): HasMany
     {
         return $this->hasMany(ChatlogPrivate::class, 'user_from_id');
     }
 
+    /** @return Collection<int, MessengerFriendship> */
     public function getOnlineFriends(int $total = 10): Collection
     {
         return $this->friends()
@@ -394,7 +422,7 @@ class User extends Authenticatable implements FilamentUser, HasName
             ->get();
     }
 
-    public function confirmTwoFactorAuthentication($code): bool
+    public function confirmTwoFactorAuthentication(string $code): bool
     {
         $codeIsValid = app(TwoFactorAuthenticationProvider::class)
             ->verify(decrypt($this->two_factor_secret), $code);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -422,8 +422,12 @@ class User extends Authenticatable implements FilamentUser, HasName
             ->get();
     }
 
-    public function confirmTwoFactorAuthentication(string $code): bool
+    public function confirmTwoFactorAuthentication(?string $code): bool
     {
+        if ($code === null) {
+            return false;
+        }
+
         $codeIsValid = app(TwoFactorAuthenticationProvider::class)
             ->verify(decrypt($this->two_factor_secret), $code);
 

--- a/app/Models/User/Ban.php
+++ b/app/Models/User/Ban.php
@@ -53,11 +53,13 @@ class Ban extends Model
 
     public $timestamps = false;
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<User, $this> */
     public function staff(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_staff_id');

--- a/app/Models/User/ClaimedReferralLog.php
+++ b/app/Models/User/ClaimedReferralLog.php
@@ -30,6 +30,7 @@ class ClaimedReferralLog extends Model
 {
     protected $guarded = ['id'];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/User/UserReferral.php
+++ b/app/Models/User/UserReferral.php
@@ -30,6 +30,7 @@ class UserReferral extends Model
 {
     protected $guarded = ['id'];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/WebsiteAd.php
+++ b/app/Models/WebsiteAd.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Services\SettingsService;
 use Exception;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -29,6 +30,7 @@ use Illuminate\Support\Facades\Storage;
  */
 class WebsiteAd extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/WebsiteBadge.php
+++ b/app/Models/WebsiteBadge.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -28,6 +29,7 @@ use Illuminate\Support\Carbon;
  */
 class WebsiteBadge extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/Models/WebsiteDrawBadge.php
+++ b/app/Models/WebsiteDrawBadge.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 
 /**
@@ -38,7 +39,8 @@ class WebsiteDrawBadge extends Model
 
     protected $guarded = ['id'];
 
-    public function user()
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }

--- a/app/Models/Wordfilter.php
+++ b/app/Models/Wordfilter.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\LogOptions;
@@ -31,7 +32,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  */
 class Wordfilter extends Model
 {
+    /** @use HasFactory<Factory<static>> */
     use HasFactory;
+
     use LogsActivity;
 
     protected $guarded = [];

--- a/app/Services/SettingsService.php
+++ b/app/Services/SettingsService.php
@@ -33,6 +33,13 @@ class SettingsService
         return $this->cachedSettings;
     }
 
+    /**
+     * @template TDefault
+     *
+     * @param  TDefault  $default
+     *
+     * @return string|TDefault
+     */
     public function getOrDefault(string $key, mixed $default = null): mixed
     {
         return $this->settings()->get($key, $default);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,10 +24,6 @@ parameters:
         - identifier: booleanNot.alwaysTrue
           path: app/Http/Middleware/InstallationMiddleware.php
 
-        # Collection items have properties at runtime that PHPStan can't infer through closures
-        - identifier: property.notFound
-          path: app/Livewire/ArticleReactions.php
-
         # Nullsafe is intentional - these relations CAN be null at runtime despite PHPDoc
         - identifier: nullsafe.neverNull
           path: app/Models/User.php

--- a/tests/Feature/User/TwoFactorTest.php
+++ b/tests/Feature/User/TwoFactorTest.php
@@ -44,6 +44,16 @@ test('an invalid code is rejected', function () {
     expect((bool) $this->user->fresh()->two_factor_confirmed)->toBeFalse();
 });
 
+test('an empty code is rejected without a server error', function () {
+    $this->actingAs($this->user)->post(route('user.two-factor.enable'));
+
+    $this->actingAs($this->user)
+        ->post(route('two-factor.verify'), ['code' => ''])
+        ->assertSessionHasErrors();
+
+    expect((bool) $this->user->fresh()->two_factor_confirmed)->toBeFalse();
+});
+
 test('two-factor authentication can be disabled', function () {
     $this->actingAs($this->user)->post(route('user.two-factor.enable'));
 


### PR DESCRIPTION
## Summary
- resolve every PHPStan level-6 finding in the Eloquent model layer
- document factory, relation, scope, accessor, and collection contracts
- type string-backed website settings at their domain boundaries
- remove an unused recursive voucher-usage relation and a stale analysis suppression

## Dependency
- stacked on #121

## Verification
- `vendor/bin/phpstan analyse app/Models --level=6 --memory-limit=1G --no-progress`
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/pint --test` on changed PHP files
- `git diff --check`