### PR TITLE
refactor: enable level seven static analysis

### DIFF
--- a/app/Casts/PurifiedHtml.php
+++ b/app/Casts/PurifiedHtml.php
@@ -5,6 +5,7 @@ namespace App\Casts;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
 use Stevebauman\Purify\Facades\Purify;
+use UnexpectedValueException;
 
 /**
  * Sanitises rich-text HTML on read, so stored editor content (including legacy
@@ -16,7 +17,17 @@ class PurifiedHtml implements CastsAttributes
 {
     public function get(Model $model, string $key, mixed $value, array $attributes): ?string
     {
-        return $value === null ? null : Purify::clean($value);
+        if ($value === null) {
+            return null;
+        }
+
+        $cleaned = Purify::clean((string) $value);
+
+        if (! is_string($cleaned)) {
+            throw new UnexpectedValueException('Purified HTML must be a string.');
+        }
+
+        return $cleaned;
     }
 
     public function set(Model $model, string $key, mixed $value, array $attributes): mixed

--- a/app/Console/Commands/BuildTheme.php
+++ b/app/Console/Commands/BuildTheme.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
 
 class BuildTheme extends Command
 {
@@ -22,17 +23,21 @@ class BuildTheme extends Command
             return Command::FAILURE;
         }
 
-        $selectedTheme = $this->choice(
+        $selection = $this->choice(
             'Which theme would you like to build?',
             $themes->toArray(),
             0,
         );
 
-        $this->info("Building {$selectedTheme} theme...");
+        if (! is_string($selection)) {
+            $this->error('The selected theme is invalid.');
 
-        $this->runBuildCommand($selectedTheme);
+            return Command::FAILURE;
+        }
 
-        return Command::SUCCESS;
+        $this->info("Building {$selection} theme...");
+
+        return $this->runBuildCommand($selection);
     }
 
     /** @return Collection<int, string> */
@@ -49,22 +54,20 @@ class BuildTheme extends Command
             ->sort();
     }
 
-    private function runBuildCommand(string $theme): void
+    private function runBuildCommand(string $theme): int
     {
-        $command = escapeshellcmd("npm run build:{$theme}");
-        $output = [];
-        $returnCode = 0;
+        $process = new Process(['npm', 'run', "build:{$theme}"], base_path());
+        $process->setTimeout(300);
+        $process->run(fn (string $type, string $buffer) => $this->output->write($buffer));
 
-        exec($command, $output, $returnCode);
-
-        foreach ($output as $line) {
-            $this->line($line);
-        }
-
-        if ($returnCode === 0) {
+        if ($process->isSuccessful()) {
             $this->info("Theme {$theme} built successfully!");
-        } else {
-            $this->error("Failed to build theme {$theme}");
+
+            return Command::SUCCESS;
         }
+
+        $this->error("Failed to build theme {$theme}");
+
+        return Command::FAILURE;
     }
 }

--- a/app/Console/Commands/ImportAdsData.php
+++ b/app/Console/Commands/ImportAdsData.php
@@ -58,12 +58,18 @@ class ImportAdsData extends Command
     /** @return list<string> */
     private function getImageFiles(string $adsPath): array
     {
-        return array_filter(scandir($adsPath), function ($file) use ($adsPath) {
+        $files = scandir($adsPath);
+
+        if ($files === false) {
+            return [];
+        }
+
+        return array_values(array_filter($files, function (string $file) use ($adsPath): bool {
             $filePath = $adsPath . DIRECTORY_SEPARATOR . $file;
 
             return is_file($filePath) &&
                    in_array(strtolower(pathinfo($file, PATHINFO_EXTENSION)), self::ALLOWED_EXTENSIONS);
-        });
+        }));
     }
 
     /** @param  list<string>  $files */

--- a/app/Emulator/Drivers/Plus/PlusBadgeRepository.php
+++ b/app/Emulator/Drivers/Plus/PlusBadgeRepository.php
@@ -43,7 +43,10 @@ class PlusBadgeRepository implements BadgeRepository
         return $this->badges($user)
             ->orderByDesc('id')
             ->paginate($perPage, ['*'], $pageName)
-            ->through(fn (object $row) => new OwnedBadge($row->badge_id, (int) $row->badge_slot));
+            ->through(fn (object $row) => new OwnedBadge(
+                (string) data_get($row, 'badge_id'),
+                (int) data_get($row, 'badge_slot'),
+            ));
     }
 
     private function badges(User $user): Builder

--- a/app/Emulator/Drivers/Plus/PlusBanRepository.php
+++ b/app/Emulator/Drivers/Plus/PlusBanRepository.php
@@ -45,6 +45,9 @@ class PlusBanRepository implements BanRepository
     {
         return $ban === null
             ? null
-            : new BanInfo((string) $ban->reason, (int) $ban->expire);
+            : new BanInfo(
+                (string) data_get($ban, 'reason'),
+                (int) data_get($ban, 'expire'),
+            );
     }
 }

--- a/app/Filament/Pages/Login.php
+++ b/app/Filament/Pages/Login.php
@@ -10,6 +10,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Component;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Validation\ValidationException;
 
 class Login extends \Filament\Auth\Pages\Login
@@ -26,10 +27,7 @@ class Login extends \Filament\Auth\Pages\Login
                     'seconds' => $exception->secondsUntilAvailable,
                     'minutes' => ceil($exception->secondsUntilAvailable / 60),
                 ]))
-                ->body(array_key_exists('body', __('filament-panels::pages/auth/login.notifications.throttled') ?: []) ? __('filament-panels::pages/auth/login.notifications.throttled.body', [
-                    'seconds' => $exception->secondsUntilAvailable,
-                    'minutes' => ceil($exception->secondsUntilAvailable / 60),
-                ]) : null)
+                ->body($this->throttledNotificationBody($exception))
                 ->danger()
                 ->send();
 
@@ -63,6 +61,22 @@ class Login extends \Filament\Auth\Pages\Login
         throw ValidationException::withMessages([
             'data.username' => __('filament-panels::pages/auth/login.messages.failed'),
         ]);
+    }
+
+    private function throttledNotificationBody(TooManyRequestsException $exception): ?string
+    {
+        $key = 'filament-panels::pages/auth/login.notifications.throttled.body';
+
+        if (! Lang::has($key)) {
+            return null;
+        }
+
+        $body = __($key, [
+            'seconds' => $exception->secondsUntilAvailable,
+            'minutes' => ceil($exception->secondsUntilAvailable / 60),
+        ]);
+
+        return is_string($body) ? $body : null;
     }
 
     /** @return array<int, Component> */

--- a/app/Filament/Resources/Hotel/BadgeTextEditors/Pages/ListBadgeTextEditors.php
+++ b/app/Filament/Resources/Hotel/BadgeTextEditors/Pages/ListBadgeTextEditors.php
@@ -65,12 +65,27 @@ class ListBadgeTextEditors extends ListRecords
             return;
         }
 
-        $jsonData = json_decode(file_get_contents($jsonPath), true);
+        $contents = file_get_contents($jsonPath);
+        $jsonData = $contents === false ? null : json_decode($contents, true);
+
+        if (! is_array($jsonData)) {
+            Notification::make()
+                ->title('Export Failed')
+                ->body('The JSON file could not be read or contains invalid data.')
+                ->danger()
+                ->send();
+
+            return;
+        }
 
         $badges = WebsiteBadge::all();
         $badgeKeys = $badges->pluck('badge_key')->toArray();
 
         foreach ($jsonData as $key => $value) {
+            if (! is_string($key)) {
+                continue;
+            }
+
             if (
                 (str_starts_with($key, 'badge_desc_') || str_starts_with($key, 'badge_name_')) &&
                 ! in_array(str_replace(['badge_desc_', 'badge_name_'], '', $key), $badgeKeys)

--- a/app/Filament/Resources/Hotel/CatalogEditors/Tables/CatalogItemsTable.php
+++ b/app/Filament/Resources/Hotel/CatalogEditors/Tables/CatalogItemsTable.php
@@ -134,7 +134,9 @@ class CatalogItemsTable
                         ->orderBy('caption')
                         ->limit(50)
                         ->pluck('caption', 'id'))
-                    ->getOptionLabelUsing(fn ($value) => CatalogPage::find($value)?->caption),
+                    ->getOptionLabelUsing(fn (int|string|null $value): ?string => $value === null
+                        ? null
+                        : CatalogPage::query()->find((int) $value)?->caption),
             ])
             ->action(function (Collection $records, array $data) use ($reorder): void {
                 $moved = $reorder->moveItemsToPage((int) $data['page_id'], $records->pluck('id')->all());

--- a/app/Filament/Tables/Columns/HabboBadgeColumn.php
+++ b/app/Filament/Tables/Columns/HabboBadgeColumn.php
@@ -13,7 +13,7 @@ class HabboBadgeColumn extends Column implements HasBadge
     {
         $record = $this->getRecord();
 
-        if (! method_exists($record, 'getBadgePath')) {
+        if (! $record instanceof HasBadge) {
             return '';
         }
 
@@ -24,7 +24,7 @@ class HabboBadgeColumn extends Column implements HasBadge
     {
         $record = $this->getRecord();
 
-        if (! method_exists($record, 'getBadgeName')) {
+        if (! $record instanceof HasBadge) {
             return '';
         }
 

--- a/app/Filament/Traits/TranslatableResource.php
+++ b/app/Filament/Traits/TranslatableResource.php
@@ -2,14 +2,28 @@
 
 namespace App\Filament\Traits;
 
+use BackedEnum;
 use Str;
+use UnitEnum;
 
 trait TranslatableResource
 {
     public static function getNavigationGroup(): ?string
     {
+        $navigationGroup = static::$navigationGroup;
+
+        if ($navigationGroup === null) {
+            return null;
+        }
+
+        if ($navigationGroup instanceof BackedEnum) {
+            $navigationGroup = (string) $navigationGroup->value;
+        } elseif ($navigationGroup instanceof UnitEnum) {
+            $navigationGroup = $navigationGroup->name;
+        }
+
         return __(
-            sprintf('filament::resources.navigations.%s', static::$navigationGroup),
+            sprintf('filament::resources.navigations.%s', $navigationGroup),
         );
     }
 

--- a/app/Helpers/helper.php
+++ b/app/Helpers/helper.php
@@ -36,9 +36,11 @@ if (! function_exists('findMigration')) {
     function findMigration(string $tableName): string
     {
         // Iterate through all migration files in the migrations directory
-        foreach (glob(database_path('migrations/*.php')) as $filename) {
+        foreach (glob(database_path('migrations/*.php')) ?: [] as $filename) {
             // Check if the migration file has the Schema::create() line with the given table name
-            if (str_contains(file_get_contents($filename), "Schema::create('$tableName'")) {
+            $contents = file_get_contents($filename);
+
+            if (is_string($contents) && str_contains($contents, "Schema::create('$tableName'")) {
                 return basename($filename);
             }
         }

--- a/app/Http/Controllers/Badge/BadgeController.php
+++ b/app/Http/Controllers/Badge/BadgeController.php
@@ -25,7 +25,12 @@ class BadgeController extends Controller
 
     public function buy(BadgePurchaseRequest $request, CreateDrawnBadge $createDrawnBadge): JsonResponse
     {
-        $badge = $createDrawnBadge->execute($request->user(), $request->validated());
+        $validated = $request->validated();
+        $badge = $createDrawnBadge->execute($request->user(), [
+            'badge_data' => (string) $validated['badge_data'],
+            'badge_name' => (string) $validated['badge_name'],
+            'badge_description' => (string) $validated['badge_description'],
+        ]);
 
         return response()->json(['success' => true, 'badge_path_filesystem' => $badge->badge_path]);
     }

--- a/app/Http/Controllers/Miscellaneous/InstallationController.php
+++ b/app/Http/Controllers/Miscellaneous/InstallationController.php
@@ -39,8 +39,16 @@ class InstallationController extends Controller
     public function showStep(int $currentStep): View
     {
         $settings = $this->getSettingsForStep($currentStep);
+        $view = match ($currentStep) {
+            1 => 'installation.step-1',
+            2 => 'installation.step-2',
+            3 => 'installation.step-3',
+            4 => 'installation.step-4',
+            5 => 'installation.step-5',
+            default => throw new Exception('Step does not exist'),
+        };
 
-        return view('installation.step-' . $currentStep, [
+        return view($view, [
             'settings' => $settings,
         ]);
     }
@@ -109,7 +117,8 @@ class InstallationController extends Controller
     /** @return Collection<int, WebsiteSetting> */
     private function getSettingsForStep(int $step): Collection
     {
-        $settingsData = array_chunk(WebsiteSetting::all()->pluck('key')->toArray(), (int) ceil(WebsiteSetting::count() / 4));
+        $chunkSize = max(1, (int) ceil(WebsiteSetting::count() / 4));
+        $settingsData = array_chunk(WebsiteSetting::all()->pluck('key')->toArray(), $chunkSize);
 
         $settings = match ($step) {
             1 => $settingsData[0] ?? [],

--- a/app/Http/Controllers/Shop/PaypalController.php
+++ b/app/Http/Controllers/Shop/PaypalController.php
@@ -25,14 +25,19 @@ class PaypalController extends Controller
     {
         $response = $this->provider->createOrder($this->buildOrderData($request->integer('amount')));
 
-        $approvalUrl = isset($response['id']) ? $this->approvalUrl($response['links'] ?? []) : null;
+        if (! is_array($response)) {
+            return $this->orderCreationFailed(['message' => 'PayPal returned an invalid order response.']);
+        }
+
+        $orderId = $response['id'] ?? null;
+        $approvalUrl = is_string($orderId) ? $this->approvalUrl($response['links'] ?? null) : null;
 
         if ($approvalUrl === null) {
             return $this->orderCreationFailed($response);
         }
 
         $request->user()->transactions()->create([
-            'transaction_id' => $response['id'],
+            'transaction_id' => $orderId,
             'amount' => 0,
         ]);
 
@@ -65,14 +70,21 @@ class PaypalController extends Controller
         ];
     }
 
-    /**
-     * @param  array<int, array{rel?: string, href?: string}>  $links
-     */
-    private function approvalUrl(array $links): ?string
+    private function approvalUrl(mixed $links): ?string
     {
+        if (! is_array($links)) {
+            return null;
+        }
+
         foreach ($links as $link) {
-            if (($link['rel'] ?? null) === 'approve') {
-                return $link['href'] ?? null;
+            if (! is_array($link) || ($link['rel'] ?? null) !== 'approve') {
+                continue;
+            }
+
+            $href = $link['href'] ?? null;
+
+            if (is_string($href)) {
+                return $href;
             }
         }
 
@@ -108,9 +120,16 @@ class PaypalController extends Controller
         }
 
         $response = $this->provider->capturePaymentOrder($request['token']);
+
+        if (! is_array($response)) {
+            $this->recordFailure($transaction, ['message' => 'PayPal returned an invalid capture response.']);
+
+            return to_route('shop.index')->withErrors(['message' => __('Something went wrong, please check your paypal account to make sure nothing was deducted and try again')]);
+        }
+
         $capture = data_get($response, 'purchase_units.0.payments.captures.0');
 
-        if (! isset($response['status']) || $capture === null) {
+        if (! is_string($response['status'] ?? null) || ! is_array($capture)) {
             $this->recordFailure($transaction, $response);
 
             return to_route('shop.index')->withErrors(['message' => __('Something went wrong, please check your paypal account to make sure nothing was deducted and try again')]);

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -75,7 +75,7 @@ class Article extends Model
         parent::boot();
 
         static::creating(function (Article $article) {
-            $article->user_id = Auth::id();
+            $article->user_id = (int) Auth::id();
             $article->slug = Str::slug($article->title);
         });
 

--- a/app/Models/Community/Staff/WebsiteTeam.php
+++ b/app/Models/Community/Staff/WebsiteTeam.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Community\Staff;
 
+use App\Models\Compositions\HasBadge;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -36,7 +37,7 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
-class WebsiteTeam extends Model
+class WebsiteTeam extends Model implements HasBadge
 {
     protected $guarded = [];
 

--- a/app/Models/Compositions/HasHome.php
+++ b/app/Models/Compositions/HasHome.php
@@ -115,7 +115,7 @@ trait HasHome
             ->selectRaw('AVG(rating) as rating_avg, COUNT(*) as total, COUNT(IF(rating >= 4, 4, NULL)) as most_positive')
             ->first();
 
-        $this->homeRatingStats->rating_avg = number_format($this->homeRatingStats->rating_avg ?? 0, 1);
+        $this->homeRatingStats->rating_avg = number_format((float) ($this->homeRatingStats->rating_avg ?? 0), 1);
 
         return $this;
     }

--- a/app/Models/Help/WebsiteHelpCenterTicket.php
+++ b/app/Models/Help/WebsiteHelpCenterTicket.php
@@ -84,6 +84,8 @@ class WebsiteHelpCenterTicket extends Model
 
     public function getContentAttribute(string $value): string
     {
-        return (string) Purify::clean($value);
+        $cleaned = Purify::clean($value);
+
+        return is_string($cleaned) ? $cleaned : '';
     }
 }

--- a/app/Models/Help/WebsiteHelpCenterTicketReply.php
+++ b/app/Models/Help/WebsiteHelpCenterTicketReply.php
@@ -54,6 +54,8 @@ class WebsiteHelpCenterTicketReply extends Model
 
     public function getContentAttribute(string $value): string
     {
-        return (string) Purify::clean($value);
+        $cleaned = Purify::clean($value);
+
+        return is_string($cleaned) ? $cleaned : '';
     }
 }

--- a/app/Services/Articles/ReactionService.php
+++ b/app/Services/Articles/ReactionService.php
@@ -30,7 +30,7 @@ class ReactionService
 
         return [
             'success' => true,
-            'added' => $existingReaction->active ?? true,
+            'added' => (bool) ($existingReaction->active ?? true),
             'username' => $user->username,
         ];
     }

--- a/app/Services/Community/StaffService.php
+++ b/app/Services/Community/StaffService.php
@@ -52,10 +52,13 @@ class StaffService
             return Cache::get('staff_ids');
         }
 
-        $staffIds = User::select('id')
+        $staffIds = array_values(User::select('id')
             ->where('rank', '>=', setting('min_staff_rank'))
             ->get()
-            ->pluck('id')->toArray();
+            ->pluck('id')
+            ->map(fn (mixed $id): int => (int) $id)
+            ->values()
+            ->all());
 
         if ($cacheEnabled) {
             $cacheTimer = (int) setting('cache_timer');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
     paths:
         - app/
 
-    level: 6
+    level: 7
 
     treatPhpDocTypesAsCertain: false
 


### PR DESCRIPTION
## Summary
- resolve all 54 PHPStan level-7 findings
- validate dynamic PayPal, file, translation, and database-row results
- run theme builds without a shell and propagate npm failures
- allowlist installer views and remove unsafe dynamic assumptions
- raise the configured PHPStan level from 6 to 7

## Dependency
- stacked on #123

## Verification
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- `vendor/bin/pest` - 141 tests, 400 assertions
- `vendor/bin/pint --test` on changed PHP files
- `git diff --check`