### PR TITLE
fix: make badge file operations atomic

### DIFF
--- a/app/Actions/Badge/CreateDrawnBadge.php
+++ b/app/Actions/Badge/CreateDrawnBadge.php
@@ -9,7 +9,10 @@ use App\Models\User;
 use App\Models\WebsiteDrawBadge;
 use App\Rules\ValidGifBadge;
 use App\Services\SettingsService;
+use ErrorException;
+use GdImage;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -43,7 +46,7 @@ class CreateDrawnBadge
             });
         } catch (Throwable $exception) {
             // The charge or record rolled back; do not leave the file behind.
-            @unlink($path);
+            $this->deleteStoredFile($path);
 
             throw $exception;
         }
@@ -53,25 +56,67 @@ class CreateDrawnBadge
     {
         $directory = $this->settings->getOrDefault('badge_path_filesystem');
 
-        if (! $directory || $bytes === null) {
+        if (! is_string($directory) || $directory === '' || ! is_dir($directory) || ! is_writable($directory) || $bytes === null) {
             throw BadgePurchaseException::pathNotConfigured();
         }
 
-        $image = @imagecreatefromstring($bytes);
+        $image = $this->decodeImage($bytes);
+        $path = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $user->id . '_' . Str::ulid() . '.gif';
+
+        try {
+            $saved = imagegif($image, $path);
+        } catch (Throwable) {
+            $saved = false;
+        } finally {
+            imagedestroy($image);
+        }
+
+        if (! $saved) {
+            $this->deleteStoredFile($path);
+
+            throw BadgePurchaseException::saveFailed();
+        }
+
+        return $path;
+    }
+
+    private function decodeImage(string $bytes): GdImage
+    {
+        set_error_handler(static function (int $severity, string $message): never {
+            throw new ErrorException($message, severity: $severity);
+        });
+
+        try {
+            $image = imagecreatefromstring($bytes);
+        } catch (Throwable) {
+            throw BadgePurchaseException::saveFailed();
+        } finally {
+            restore_error_handler();
+        }
 
         if ($image === false) {
             throw BadgePurchaseException::saveFailed();
         }
 
-        $path = rtrim($directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $user->id . '_' . Str::ulid() . '.gif';
-        $saved = imagegif($image, $path);
-        imagedestroy($image);
+        return $image;
+    }
 
-        if (! $saved) {
-            throw BadgePurchaseException::saveFailed();
+    private function deleteStoredFile(string $path): void
+    {
+        if (! is_file($path)) {
+            return;
         }
 
-        return $path;
+        try {
+            if (! unlink($path)) {
+                Log::error('Failed to remove a drawn badge file.', ['path' => $path]);
+            }
+        } catch (Throwable $exception) {
+            Log::error('Failed to remove a drawn badge file.', [
+                'path' => $path,
+                'exception' => $exception,
+            ]);
+        }
     }
 
     /**

--- a/app/Actions/Badge/PurgeDrawnBadge.php
+++ b/app/Actions/Badge/PurgeDrawnBadge.php
@@ -6,6 +6,7 @@ use App\Emulator\Contracts\BadgeRepository;
 use App\Models\User;
 use App\Models\WebsiteDrawBadge;
 use App\Services\Badge\NitroExternalTexts;
+use RuntimeException;
 
 /**
  * Removes every trace of a drawn badge before its record is deleted: the
@@ -28,8 +29,8 @@ class PurgeDrawnBadge
 
         $this->externalTexts->remove($badgeCode);
 
-        if ($badge->badge_path && file_exists($badge->badge_path)) {
-            unlink($badge->badge_path);
+        if ($badge->badge_path && is_file($badge->badge_path) && ! unlink($badge->badge_path)) {
+            throw new RuntimeException("Unable to remove badge image: {$badge->badge_path}");
         }
     }
 }

--- a/app/Filament/Pages/BadgePage.php
+++ b/app/Filament/Pages/BadgePage.php
@@ -4,6 +4,7 @@ namespace App\Filament\Pages;
 
 use App\Filament\Traits\TranslatableResource;
 use App\Services\Parsers\ExternalTextsParser;
+use App\Support\BadgeCode;
 use App\Support\OutboundHttp;
 use App\Support\PublicHttpUrlResolver;
 use Filament\Actions\Action;
@@ -64,7 +65,7 @@ class BadgePage extends Page
                             ->label(__('filament::resources.inputs.badge_code'))
                             ->helperText(__('filament::resources.helpers.badge_code_helper'))
                             ->required()
-                            ->maxLength(64)
+                            ->maxLength(BadgeCode::MAX_LENGTH)
                             ->regex('/\A[A-Z0-9_-]+\z/')
                             ->afterStateUpdated(function (?string $state, Set $set) {
                                 $set('code', is_string($state) ? strtoupper($state) : null);
@@ -135,7 +136,19 @@ class BadgePage extends Page
 
         $this->data['code'] = $badgeCode;
 
-        $badgeData = app(ExternalTextsParser::class)->getBadgeData($badgeCode);
+        try {
+            $badgeData = app(ExternalTextsParser::class)->getBadgeData($badgeCode);
+        } catch (Throwable $exception) {
+            Log::channel('badge')->error('[ORION BADGE RESOURCE] - ERROR: ' . $exception->getMessage());
+
+            Notification::make()
+                ->danger()
+                ->title(__('filament::resources.notifications.badge_update_failed'))
+                ->send();
+
+            return;
+        }
+
         $this->badgeWasPreviouslyCreated = is_array($badgeData['nitro']) || is_array($badgeData['flash']);
 
         if ($this->badgeWasPreviouslyCreated) {
@@ -361,15 +374,7 @@ class BadgePage extends Page
 
     private function badgeCode(): ?string
     {
-        $code = $this->data['code'] ?? null;
-
-        if (! is_string($code)) {
-            return null;
-        }
-
-        $code = strtoupper(trim($code));
-
-        return preg_match('/\A[A-Z0-9_-]{1,64}\z/', $code) === 1 ? $code : null;
+        return BadgeCode::normalize($this->data['code'] ?? null);
     }
 
     private function notifyBadgeImageUploadFailed(): void

--- a/app/Rules/ValidGifBadge.php
+++ b/app/Rules/ValidGifBadge.php
@@ -3,7 +3,9 @@
 namespace App\Rules;
 
 use Closure;
+use ErrorException;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Throwable;
 
 class ValidGifBadge implements ValidationRule
 {
@@ -29,7 +31,7 @@ class ValidGifBadge implements ValidationRule
             return;
         }
 
-        $info = @getimagesizefromstring($decoded);
+        $info = $this->imageInfo($decoded);
 
         if ($info === false || $info['mime'] !== 'image/gif' || $info[0] !== self::WIDTH || $info[1] !== self::HEIGHT) {
             $fail('The badge must be a 40x40 GIF image.');
@@ -45,5 +47,21 @@ class ValidGifBadge implements ValidationRule
         $decoded = base64_decode($stripped, true);
 
         return $decoded === false ? null : $decoded;
+    }
+
+    /** @return array<int|string, int|string>|false */
+    private function imageInfo(string $bytes): array|false
+    {
+        set_error_handler(static function (int $severity, string $message): never {
+            throw new ErrorException($message, severity: $severity);
+        });
+
+        try {
+            return getimagesizefromstring($bytes);
+        } catch (Throwable) {
+            return false;
+        } finally {
+            restore_error_handler();
+        }
     }
 }

--- a/app/Services/Badge/FlashExternalTexts.php
+++ b/app/Services/Badge/FlashExternalTexts.php
@@ -3,6 +3,10 @@
 namespace App\Services\Badge;
 
 use App\Services\SettingsService;
+use App\Support\AtomicFileWriter;
+use App\Support\BadgeCode;
+use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Maintains the badge name/description entries in the flash client's
@@ -11,13 +15,17 @@ use App\Services\SettingsService;
  */
 class FlashExternalTexts
 {
-    public function __construct(private readonly SettingsService $settings) {}
+    public function __construct(
+        private readonly SettingsService $settings,
+        private readonly AtomicFileWriter $files,
+    ) {}
 
     /**
      * @return array{title: string, description: string}|null null when the badge has no entries
      */
     public function find(string $badgeCode): ?array
     {
+        $badgeCode = BadgeCode::ensure($badgeCode);
         $texts = $this->all();
 
         $name = $texts["badge_name_{$badgeCode}"] ?? null;
@@ -38,34 +46,38 @@ class FlashExternalTexts
      */
     public function add(string $badgeCode, ?string $title, ?string $description): void
     {
+        $badgeCode = BadgeCode::ensure($badgeCode);
         $path = $this->path();
 
-        if (! $path || ! file_exists($path) || ! is_writable($path)) {
+        if ($path === null) {
             return;
         }
 
-        $lines = preg_split('/\r\n|\n/', rtrim((string) file_get_contents($path)));
-        $lines = $lines === false ? [] : $lines;
-
         $entries = [
-            "badge_name_{$badgeCode}" => (string) ($title ?? ''),
-            "badge_desc_{$badgeCode}" => (string) ($description ?? ''),
+            "badge_name_{$badgeCode}" => $this->value($title),
+            "badge_desc_{$badgeCode}" => $this->value($description),
         ];
 
-        foreach ($lines as $index => $line) {
-            [$key] = explode('=', $line, 2);
+        $this->files->rewrite($path, function (string $contents) use ($entries): string {
+            $lines = preg_split('/\r\n|\n/', rtrim($contents));
+            $lines = $lines === false ? [] : $lines;
+            $pending = $entries;
 
-            if (array_key_exists($key, $entries)) {
-                $lines[$index] = $key . '=' . $entries[$key];
-                unset($entries[$key]);
+            foreach ($lines as $index => $line) {
+                [$key] = explode('=', $line, 2);
+
+                if (array_key_exists($key, $pending)) {
+                    $lines[$index] = $key . '=' . $pending[$key];
+                    unset($pending[$key]);
+                }
             }
-        }
 
-        foreach ($entries as $key => $value) {
-            $lines[] = $key . '=' . $value;
-        }
+            foreach ($pending as $key => $value) {
+                $lines[] = $key . '=' . $value;
+            }
 
-        file_put_contents($path, implode("\n", $lines) . "\n");
+            return implode("\n", $lines) . "\n";
+        });
     }
 
     /**
@@ -75,13 +87,19 @@ class FlashExternalTexts
     {
         $path = $this->path();
 
-        if (! $path || ! file_exists($path)) {
+        if ($path === null) {
             return [];
+        }
+
+        $contents = file_get_contents($path);
+
+        if ($contents === false) {
+            throw new RuntimeException("Unable to read Flash external texts: {$path}");
         }
 
         $texts = [];
 
-        foreach (preg_split('/\r\n|\n/', (string) file_get_contents($path)) ?: [] as $line) {
+        foreach (preg_split('/\r\n|\n/', $contents) ?: [] as $line) {
             if (! str_contains($line, '=')) {
                 continue;
             }
@@ -91,6 +109,17 @@ class FlashExternalTexts
         }
 
         return $texts;
+    }
+
+    private function value(?string $value): string
+    {
+        $value ??= '';
+
+        if (str_contains($value, "\r") || str_contains($value, "\n")) {
+            throw new InvalidArgumentException('Flash external text values cannot contain line breaks.');
+        }
+
+        return $value;
     }
 
     private function path(): ?string

--- a/app/Services/Badge/NitroExternalTexts.php
+++ b/app/Services/Badge/NitroExternalTexts.php
@@ -3,6 +3,10 @@
 namespace App\Services\Badge;
 
 use App\Services\SettingsService;
+use App\Support\AtomicFileWriter;
+use App\Support\BadgeCode;
+use JsonException;
+use RuntimeException;
 
 /**
  * Maintains the badge name/description entries in the Nitro external texts
@@ -10,13 +14,17 @@ use App\Services\SettingsService;
  */
 class NitroExternalTexts
 {
-    public function __construct(private readonly SettingsService $settings) {}
+    public function __construct(
+        private readonly SettingsService $settings,
+        private readonly AtomicFileWriter $files,
+    ) {}
 
     /**
      * @return array{title: string, description: string}|null null when the badge has no entries
      */
     public function find(string $badgeCode): ?array
     {
+        $badgeCode = BadgeCode::ensure($badgeCode);
         $texts = $this->read();
 
         $name = $texts["badge_name_{$badgeCode}"] ?? null;
@@ -34,6 +42,8 @@ class NitroExternalTexts
 
     public function add(string $badgeCode, ?string $name, ?string $description): void
     {
+        $badgeCode = BadgeCode::ensure($badgeCode);
+
         $this->rewrite(fn (array $texts): array => array_merge($texts, [
             "badge_name_{$badgeCode}" => $name,
             "badge_desc_{$badgeCode}" => $description,
@@ -42,6 +52,8 @@ class NitroExternalTexts
 
     public function remove(string $badgeCode): void
     {
+        $badgeCode = BadgeCode::ensure($badgeCode);
+
         $this->rewrite(function (array $texts) use ($badgeCode): array {
             unset($texts["badge_name_{$badgeCode}"], $texts["badge_desc_{$badgeCode}"]);
 
@@ -56,17 +68,17 @@ class NitroExternalTexts
     {
         $path = $this->path();
 
-        if (! $path || ! file_exists($path) || ! is_writable($path)) {
+        if ($path === null) {
             return;
         }
 
-        $texts = json_decode((string) file_get_contents($path), true);
-
-        if (! is_array($texts)) {
-            return;
-        }
-
-        file_put_contents($path, json_encode($mutate($texts), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        $this->files->rewrite(
+            $path,
+            fn (string $contents): string => json_encode(
+                $mutate($this->decode($contents, $path)),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+            ) . "\n",
+        );
     }
 
     /**
@@ -76,13 +88,33 @@ class NitroExternalTexts
     {
         $path = $this->path();
 
-        if (! $path || ! file_exists($path)) {
+        if ($path === null) {
             return [];
         }
 
-        $texts = json_decode((string) file_get_contents($path), true);
+        $contents = file_get_contents($path);
 
-        return is_array($texts) ? $texts : [];
+        if ($contents === false) {
+            throw new RuntimeException("Unable to read Nitro external texts: {$path}");
+        }
+
+        return $this->decode($contents, $path);
+    }
+
+    /** @return array<string, mixed> */
+    private function decode(string $contents, string $path): array
+    {
+        try {
+            $texts = json_decode($contents, flags: JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new RuntimeException("Nitro external texts contain invalid JSON: {$path}", previous: $exception);
+        }
+
+        if (! is_object($texts)) {
+            throw new RuntimeException("Nitro external texts must contain a JSON object: {$path}");
+        }
+
+        return get_object_vars($texts);
     }
 
     private function path(): ?string

--- a/app/Services/Parsers/ExternalTextsParser.php
+++ b/app/Services/Parsers/ExternalTextsParser.php
@@ -4,6 +4,7 @@ namespace App\Services\Parsers;
 
 use App\Services\Badge\FlashExternalTexts;
 use App\Services\Badge\NitroExternalTexts;
+use App\Support\BadgeCode;
 
 /**
  * Reads and writes a badge's name/description across the client text files -
@@ -26,6 +27,8 @@ class ExternalTextsParser
      */
     public function getBadgeData(string $code): array
     {
+        $code = BadgeCode::ensure($code);
+
         return [
             'image' => file_exists($this->badgeImagePath($code)) ? $this->getBadgeImageUrl($code) : null,
             'nitro' => $this->nitroTexts->find($code),
@@ -39,16 +42,18 @@ class ExternalTextsParser
      */
     public function updateNitroBadgeTexts(string $code, string $title = '', string $description = ''): void
     {
-        $this->nitroTexts->add($code, $title, $description);
+        $this->nitroTexts->add(BadgeCode::ensure($code), $title, $description);
     }
 
     public function updateFlashBadgeTexts(string $code, string $title = '', string $description = ''): void
     {
-        $this->flashTexts->add($code, $title, $description);
+        $this->flashTexts->add(BadgeCode::ensure($code), $title, $description);
     }
 
     public function getBadgeImageUrl(string $code): string
     {
+        $code = BadgeCode::ensure($code);
+
         return url(sprintf('%s/c_images/album1584/%s.gif', $this->clientPath(), $code));
     }
 

--- a/app/Support/AtomicFileWriter.php
+++ b/app/Support/AtomicFileWriter.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Support;
+
+use Closure;
+use RuntimeException;
+use Throwable;
+
+final class AtomicFileWriter
+{
+    /** @param Closure(string): string $mutate */
+    public function rewrite(string $path, Closure $mutate): void
+    {
+        $path = realpath($path) ?: $path;
+
+        if (! is_file($path) || ! is_readable($path) || ! is_writable($path)) {
+            throw new RuntimeException("File cannot be safely rewritten: {$path}");
+        }
+
+        $directory = dirname($path);
+
+        if (! is_writable($directory)) {
+            throw new RuntimeException("File directory is not writable: {$directory}");
+        }
+
+        $lock = fopen($path . '.lock', 'c');
+
+        if ($lock === false) {
+            throw new RuntimeException("Unable to open file lock: {$path}.lock");
+        }
+
+        try {
+            if (! flock($lock, LOCK_EX)) {
+                throw new RuntimeException("Unable to acquire file lock: {$path}.lock");
+            }
+
+            $contents = file_get_contents($path);
+
+            if ($contents === false) {
+                throw new RuntimeException("Unable to read file: {$path}");
+            }
+
+            $this->replace($path, $mutate($contents));
+        } finally {
+            flock($lock, LOCK_UN);
+            fclose($lock);
+        }
+    }
+
+    private function replace(string $path, string $contents): void
+    {
+        $mode = fileperms($path);
+
+        if ($mode === false) {
+            throw new RuntimeException("Unable to read file permissions: {$path}");
+        }
+
+        $temporaryPath = tempnam(dirname($path), '.' . basename($path) . '.');
+
+        if ($temporaryPath === false) {
+            throw new RuntimeException("Unable to create temporary file for: {$path}");
+        }
+
+        try {
+            $this->write($temporaryPath, $contents);
+
+            if (! chmod($temporaryPath, $mode & 0777)) {
+                throw new RuntimeException("Unable to preserve file permissions: {$path}");
+            }
+
+            if (! rename($temporaryPath, $path)) {
+                throw new RuntimeException("Unable to replace file: {$path}");
+            }
+        } catch (Throwable $exception) {
+            if (is_file($temporaryPath)) {
+                try {
+                    unlink($temporaryPath);
+                } catch (Throwable $cleanupException) {
+                    throw new RuntimeException(
+                        "Unable to clean up temporary file: {$temporaryPath}",
+                        previous: $exception,
+                    );
+                }
+            }
+
+            throw $exception;
+        }
+    }
+
+    private function write(string $path, string $contents): void
+    {
+        $file = fopen($path, 'wb');
+
+        if ($file === false) {
+            throw new RuntimeException("Unable to open temporary file: {$path}");
+        }
+
+        try {
+            $remaining = $contents;
+
+            while ($remaining !== '') {
+                $written = fwrite($file, $remaining);
+
+                if ($written === false || $written === 0) {
+                    throw new RuntimeException("Unable to write temporary file: {$path}");
+                }
+
+                $remaining = substr($remaining, $written);
+            }
+
+            if (! fflush($file) || ! fsync($file)) {
+                throw new RuntimeException("Unable to flush temporary file: {$path}");
+            }
+        } finally {
+            fclose($file);
+        }
+    }
+}

--- a/app/Support/BadgeCode.php
+++ b/app/Support/BadgeCode.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Support;
+
+use InvalidArgumentException;
+
+final class BadgeCode
+{
+    public const MAX_LENGTH = 64;
+
+    public static function normalize(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = strtoupper(trim($value));
+
+        return self::isValid($value) ? $value : null;
+    }
+
+    public static function ensure(string $value): string
+    {
+        if (! self::isValid($value)) {
+            throw new InvalidArgumentException('Badge codes may contain only letters, numbers, underscores, and dashes.');
+        }
+
+        return $value;
+    }
+
+    public static function isValid(string $value): bool
+    {
+        return preg_match('/\A[A-Za-z0-9_-]{1,' . self::MAX_LENGTH . '}\z/', $value) === 1;
+    }
+}

--- a/tests/Feature/Badge/BadgePurchaseTest.php
+++ b/tests/Feature/Badge/BadgePurchaseTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Actions\Badge\CreateDrawnBadge;
+use App\Exceptions\BadgePurchaseException;
 use App\Models\User;
 use App\Models\WebsiteDrawBadge;
 use Illuminate\Support\Facades\File;
@@ -83,5 +85,20 @@ test('invalid image data is rejected by validation', function () {
         ->assertSessionHasErrors('badge_data');
 
     expect(WebsiteDrawBadge::count())->toBe(0)
+        ->and((int) $user->refresh()->credits)->toBe(1000);
+});
+
+test('invalid image bytes cannot leave a partial badge or charge', function () {
+    installHotel();
+    $directory = prepareBadgeDirectory();
+    $user = User::factory()->create(['credits' => 1000]);
+
+    expect(fn () => app(CreateDrawnBadge::class)->execute($user, [
+        'badge_data' => base64_encode('not a gif'),
+        'badge_name' => 'Invalid',
+        'badge_description' => 'Invalid',
+    ]))->toThrow(BadgePurchaseException::class)
+        ->and(File::files($directory))->toBeEmpty()
+        ->and(WebsiteDrawBadge::count())->toBe(0)
         ->and((int) $user->refresh()->credits)->toBe(1000);
 });

--- a/tests/Feature/Badge/ExternalTextsParserTest.php
+++ b/tests/Feature/Badge/ExternalTextsParserTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Services\Parsers\ExternalTextsParser;
+use App\Support\BadgeCode;
 use Illuminate\Support\Facades\File;
 
 function externalTextsSetup(): ExternalTextsParser
@@ -9,6 +10,7 @@ function externalTextsSetup(): ExternalTextsParser
 
     $directory = storage_path('framework/testing/external-texts');
     File::ensureDirectoryExists($directory);
+    File::cleanDirectory($directory);
 
     $nitroPath = $directory . '/ExternalTexts.json';
     file_put_contents($nitroPath, json_encode([
@@ -81,6 +83,38 @@ test('updating an existing badge rewrites its lines in place', function () {
     expect($flash)->toContain('badge_name_ACH_Existing=Renamed')
         ->and($flash)->toContain('badge_desc_ACH_Existing=Redescribed')
         ->and(substr_count($flash, 'badge_name_ACH_Existing='))->toBe(1);
+});
+
+test('badge codes are normalized and unsafe file keys are rejected', function () {
+    $parser = externalTextsSetup();
+    $nitroPath = storage_path('framework/testing/external-texts/ExternalTexts.json');
+    $before = (string) file_get_contents($nitroPath);
+
+    expect(BadgeCode::normalize(' ach_new-1 '))->toBe('ACH_NEW-1')
+        ->and(BadgeCode::normalize('../badge'))->toBeNull()
+        ->and(fn () => $parser->updateNitroBadgeTexts('../badge', 'Unsafe', 'Unsafe'))
+        ->toThrow(InvalidArgumentException::class)
+        ->and((string) file_get_contents($nitroPath))->toBe($before);
+});
+
+test('malformed nitro texts are never overwritten', function () {
+    $parser = externalTextsSetup();
+    $nitroPath = storage_path('framework/testing/external-texts/ExternalTexts.json');
+    file_put_contents($nitroPath, '{malformed');
+
+    expect(fn () => $parser->updateNitroBadgeTexts('ACH_Safe', 'Safe', 'Safe'))
+        ->toThrow(RuntimeException::class)
+        ->and((string) file_get_contents($nitroPath))->toBe('{malformed');
+});
+
+test('flash text values cannot inject additional entries', function () {
+    $parser = externalTextsSetup();
+    $flashPath = storage_path('framework/testing/external-texts/external_flash_texts.txt');
+    $before = (string) file_get_contents($flashPath);
+
+    expect(fn () => $parser->updateFlashBadgeTexts('ACH_Safe', "Safe\ninjected.key=value", 'Safe'))
+        ->toThrow(InvalidArgumentException::class)
+        ->and((string) file_get_contents($flashPath))->toBe($before);
 });
 
 test('the badge image url and existence follow the flash client path', function () {


### PR DESCRIPTION
## Summary
- serialize external-text mutations with exclusive locks and atomic replacement
- reject malformed Nitro JSON, unsafe badge keys, and Flash line injection without changing source files
- handle GD decoding and badge-file cleanup failures explicitly
- stop housekeeping searches cleanly when configured client files are invalid

## Verification
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- scoped `vendor/bin/pint` on all changed PHP files
- targeted Pest suite: 12 passed, 42 assertions
- full Pest suite: 151 passed, 438 assertions