### PR TITLE
fix: remove replaced generated logos

### DIFF
--- a/app/Actions/ReplaceGeneratedLogo.php
+++ b/app/Actions/ReplaceGeneratedLogo.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Actions;
+
+use App\Models\Miscellaneous\WebsiteSetting;
+use App\Services\SettingsService;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+final class ReplaceGeneratedLogo
+{
+    private const DIRECTORY = 'assets/images/generated-logos';
+
+    /** @var list<string> */
+    private const EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'webp'];
+
+    public function __construct(private readonly SettingsService $settings) {}
+
+    public function execute(UploadedFile $file): string
+    {
+        return Cache::lock('generated-logo-replacement', 10)->block(
+            5,
+            fn (): string => $this->replace($file),
+        );
+    }
+
+    private function replace(UploadedFile $file): string
+    {
+        $extension = $file->guessExtension();
+
+        if (! is_string($extension) || ! in_array($extension, self::EXTENSIONS, true)) {
+            throw new RuntimeException('The generated logo has an unsupported image type.');
+        }
+
+        $directory = public_path(self::DIRECTORY);
+        File::ensureDirectoryExists($directory);
+
+        $previousPath = $this->managedPath($this->settings->getOrDefault('cms_logo'));
+        $filename = Str::uuid() . '.' . $extension;
+        $storedFile = $file->move($directory, $filename);
+        $storedPath = $storedFile->getPathname();
+        $publicPath = '/' . self::DIRECTORY . '/' . $filename;
+
+        try {
+            WebsiteSetting::query()->updateOrCreate(['key' => 'cms_logo'], [
+                'value' => $publicPath,
+                'comment' => 'CMS logo path',
+            ]);
+
+            SettingsService::clearCache();
+        } catch (Throwable $exception) {
+            $this->delete($storedPath, 'new');
+
+            throw $exception;
+        }
+
+        if ($previousPath !== null && $previousPath !== $storedPath) {
+            $this->delete($previousPath, 'previous');
+        }
+
+        return $publicPath;
+    }
+
+    private function managedPath(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $relativePath = ltrim(str_replace('\\', '/', $value), '/');
+
+        if (dirname($relativePath) !== self::DIRECTORY) {
+            return null;
+        }
+
+        $filename = basename($relativePath);
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        $identifier = pathinfo($filename, PATHINFO_FILENAME);
+
+        if (! Str::isUuid($identifier) || ! in_array($extension, self::EXTENSIONS, true)) {
+            return null;
+        }
+
+        return public_path($relativePath);
+    }
+
+    private function delete(string $path, string $kind): void
+    {
+        if (! is_file($path)) {
+            return;
+        }
+
+        if (! File::delete($path)) {
+            Log::warning("Unable to delete {$kind} generated logo.", ['path' => $path]);
+        }
+    }
+}

--- a/app/Http/Controllers/Miscellaneous/LogoGeneratorController.php
+++ b/app/Http/Controllers/Miscellaneous/LogoGeneratorController.php
@@ -2,13 +2,11 @@
 
 namespace App\Http\Controllers\Miscellaneous;
 
+use App\Actions\ReplaceGeneratedLogo;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\LogoGeneratorRequest;
-use App\Models\Miscellaneous\WebsiteSetting;
-use App\Services\SettingsService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 class LogoGeneratorController extends Controller
@@ -24,20 +22,9 @@ class LogoGeneratorController extends Controller
         return view('logo-generator');
     }
 
-    public function store(LogoGeneratorRequest $request): JsonResponse
+    public function store(LogoGeneratorRequest $request, ReplaceGeneratedLogo $replaceLogo): JsonResponse
     {
-        $file = $request->file('logo');
-        $directory = 'assets/images/generated-logos';
-        $filename = Str::uuid() . '.' . ($file->guessExtension() ?: 'png');
-
-        $file->move(public_path($directory), $filename);
-
-        WebsiteSetting::updateOrCreate(['key' => 'cms_logo'], [
-            'value' => sprintf('/%s/%s', $directory, $filename),
-            'comment' => 'CMS logo path',
-        ]);
-
-        SettingsService::clearCache();
+        $replaceLogo->execute($request->file('logo'));
 
         return response()->json(['success' => true, 'message' => 'Logo updated!']);
     }

--- a/tests/Feature/Misc/LogoGeneratorTest.php
+++ b/tests/Feature/Misc/LogoGeneratorTest.php
@@ -19,10 +19,25 @@ test('staff can upload a generated logo', function () {
         ->assertJson(['success' => true]);
 
     $logoPath = setting('cms_logo');
+    $firstAbsolutePath = public_path(ltrim((string) $logoPath, '/'));
 
     try {
         expect($logoPath)->toContain('generated-logos')
-            ->and(file_exists(public_path(ltrim((string) $logoPath, '/'))))->toBeTrue();
+            ->and(file_exists($firstAbsolutePath))->toBeTrue();
+
+        $this->actingAs($staff)
+            ->post(route('store.generated-logo'), [
+                'logo' => UploadedFile::fake()->image('replacement.webp', 120, 50),
+            ])
+            ->assertOk()
+            ->assertJson(['success' => true]);
+
+        $replacementPath = setting('cms_logo');
+
+        expect($replacementPath)->not->toBe($logoPath)
+            ->and(file_exists($firstAbsolutePath))->toBeFalse()
+            ->and(file_exists(public_path(ltrim((string) $replacementPath, '/'))))->toBeTrue()
+            ->and(File::files(public_path('assets/images/generated-logos')))->toHaveCount(1);
     } finally {
         File::deleteDirectory(public_path('assets/images/generated-logos'));
     }


### PR DESCRIPTION
## Summary
- move generated-logo replacement into a focused action
- serialize concurrent replacements with a cache lock
- remove only previous UUID-named files from the managed logo directory
- delete a newly moved file if persistence fails and preserve external logo paths

## Verification
- `vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- scoped `vendor/bin/pint` on changed PHP files
- focused logo and account tests: 9 passed, 21 assertions
- full Pest suite: 141 passed, 406 assertions