### PR TITLE
fix: isolate hidden staff cache entries

### DIFF
--- a/app/Services/Community/StaffService.php
+++ b/app/Services/Community/StaffService.php
@@ -14,33 +14,40 @@ class StaffService
     public function fetchStaffPositions(): Collection
     {
         $cacheEnabled = setting('enable_caching') === '1';
+        $viewer = Auth::user();
+        $canSeeHiddenStaff = $viewer instanceof User
+            && $viewer->rank >= (int) setting('min_rank_to_see_hidden_staff');
+        $cacheKey = $canSeeHiddenStaff ? 'staff_positions.all' : 'staff_positions.public';
 
-        if ($cacheEnabled && Cache::has('staff_positions')) {
-            return Cache::get('staff_positions');
+        if (! $cacheEnabled) {
+            return $this->staffPositions($canSeeHiddenStaff);
         }
 
-        $employees = Permission::query()
+        return Cache::remember(
+            $cacheKey,
+            now()->addMinutes((int) setting('cache_timer')),
+            fn (): Collection => $this->staffPositions($canSeeHiddenStaff),
+        );
+    }
+
+    /** @return Collection<int, Permission> */
+    private function staffPositions(bool $canSeeHiddenStaff): Collection
+    {
+        return Permission::query()
             ->select('id', 'rank_name', 'badge', 'staff_color', 'job_description')
-            ->when(Auth::user()->rank < (int) setting('min_rank_to_see_hidden_staff'), function ($query) {
+            ->when(! $canSeeHiddenStaff, function ($query) {
                 return $query->where('hidden_rank', false);
             })
             ->where('id', '>=', setting('min_staff_rank'))
             ->orderByDesc('id')
-            ->with(['users' => function ($query) {
+            ->with(['users' => function ($query) use ($canSeeHiddenStaff) {
                 $query->select('id', 'username', 'rank', 'motto', 'look', 'hidden_staff', 'online')
-                    ->when(Auth::user()->rank < (int) setting('min_rank_to_see_hidden_staff'), function ($query) {
+                    ->when(! $canSeeHiddenStaff, function ($query) {
                         return $query->where('hidden_staff', false);
                     })
                     ->with('permission:id,rank_name,staff_background');
             }])
             ->get();
-
-        if ($cacheEnabled) {
-            $cacheTimer = (int) setting('cache_timer');
-            Cache::put('staff_positions', $employees, now()->addMinutes($cacheTimer));
-        }
-
-        return $employees;
     }
 
     /** @return list<int> */


### PR DESCRIPTION
## Summary
- partition staff-directory caches by hidden-staff visibility
- evaluate visibility once for the authenticated viewer
- use an atomic cache lookup instead of separate has/get calls

## Security impact
A privileged request could previously populate the shared cache with hidden ranks and users, which lower-rank viewers could then receive. Public and privileged results now use separate cache keys.

## Verification
- `vendor/bin/pint app/Services/Community/StaffService.php`
- `vendor/bin/phpstan analyse app/Services/Community/StaffService.php --memory-limit=1G --no-progress`