### PR TITLE
fix(livewire): bundle runtime per theme so Turbolinks visits hydrate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,13 +7,11 @@
                 "swiper": "^12.2.0"
             },
             "devDependencies": {
-                "@alpinejs/focus": "^3.10.3",
                 "@prettier/plugin-php": "^0.19.3",
                 "@shufo/prettier-plugin-blade": "^1.8.6",
                 "@tailwindcss/forms": "^0.5.10",
                 "@tailwindcss/postcss": "^4.0.0",
                 "@tailwindcss/typography": "^0.5.19",
-                "alpinejs": "^3.10.3",
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.6.2",
                 "laravel-vite-plugin": "^1.3.0",
@@ -34,17 +32,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/@alpinejs/focus": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/@alpinejs/focus/-/focus-3.15.12.tgz",
-            "integrity": "sha512-lmqbFTlbQGywDgsW4dY0pv18CKhuHJrq8mffU1OO14J34uUk+lCQElmSgJdRGHYv9qBezE6zdvmhN6n2tg0A1A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "focus-trap": "^8.0.0",
-                "tabbable": "^6.4.0"
             }
         },
         "node_modules/@babel/runtime-corejs3": {
@@ -1620,23 +1607,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.1.5"
-            }
-        },
-        "node_modules/@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/abbrev": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -1692,16 +1662,6 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/alpinejs": {
-            "version": "3.15.12",
-            "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
-            "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/reactivity": "~3.1.1"
             }
         },
         "node_modules/ansi-regex": {
@@ -2713,16 +2673,6 @@
             },
             "engines": {
                 "node": ">= 0.12"
-            }
-        },
-        "node_modules/focus-trap": {
-            "version": "8.2.1",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.2.1.tgz",
-            "integrity": "sha512-6CxwrrFRquH7pDXb1mWxudkU9LSfYBMRZutpgddb2o6iwCk7cIRrBhyY3c8SGKcmIKdeMTrGSNg4Bedh2RSF/w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "tabbable": "^6.4.0"
             }
         },
         "node_modules/follow-redirects": {
@@ -4533,13 +4483,6 @@
             "engines": {
                 "node": ">= 4.7.0"
             }
-        },
-        "node_modules/tabbable": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-            "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/tailwindcss": {
             "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,11 @@
         "format": "prettier \"resources/**/*.{js,ts,vue,blade}\" --write"
     },
     "devDependencies": {
-        "@alpinejs/focus": "^3.10.3",
         "@prettier/plugin-php": "^0.19.3",
         "@shufo/prettier-plugin-blade": "^1.8.6",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/postcss": "^4.0.0",
         "@tailwindcss/typography": "^0.5.19",
-        "alpinejs": "^3.10.3",
         "autoprefixer": "^10.4.20",
         "axios": "^1.6.2",
         "laravel-vite-plugin": "^1.3.0",

--- a/resources/js/components/HomeManager.js
+++ b/resources/js/components/HomeManager.js
@@ -1,6 +1,5 @@
-import Alpine from "alpinejs";
-
-Alpine.data('homeManager', (username, isMe) => ({
+document.addEventListener("alpine:init", () => {
+    window.Alpine.data('homeManager', (username, isMe) => ({
     username,
     isMe,
     editing: false,
@@ -829,4 +828,5 @@ Alpine.data('homeManager', (username, isMe) => ({
 
         return res.json();
     },
-}));
+    }));
+});

--- a/resources/themes/atom/js/app.js
+++ b/resources/themes/atom/js/app.js
@@ -16,9 +16,26 @@ AtomSliders.init();
 
 window.Alpine = Alpine;
 
-const startLivewire = () => Livewire.start();
+const livewireStartedKey = Symbol.for("atomcms.livewire.started");
+const startLivewire = () => {
+    if (window[livewireStartedKey]) {
+        return;
+    }
+
+    window[livewireStartedKey] = true;
+
+    try {
+        Livewire.start();
+    } catch (error) {
+        delete window[livewireStartedKey];
+        throw error;
+    }
+};
+
 if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", startLivewire, { once: true });
+    document.addEventListener("DOMContentLoaded", startLivewire, {
+        once: true,
+    });
 } else {
     startLivewire();
 }

--- a/resources/themes/atom/js/app.js
+++ b/resources/themes/atom/js/app.js
@@ -4,8 +4,7 @@ import "./external/flowbite";
 import "swiper/css";
 import "swiper/css/pagination";
 
-import Alpine from "alpinejs";
-import Focus from "@alpinejs/focus";
+import { Livewire, Alpine } from "livewire";
 
 import ThemeSwitcher from "./components/ThemeSwitcher.js";
 import AtomSliders from "./components/AtomSliders.js";
@@ -14,8 +13,15 @@ import "../../../js/components/HomeManager.js";
 
 ThemeSwitcher.init();
 AtomSliders.init();
-Alpine.plugin(Focus);
-Alpine.start();
+
+window.Alpine = Alpine;
+
+const startLivewire = () => Livewire.start();
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", startLivewire, { once: true });
+} else {
+    startLivewire();
+}
 
 console.log(
     "%cAtom CMS%c\n\nAtom CMS is a CMS for made for the community to enjoy. You can join our wonderful community at https://discord.gg/rX3aShUHdg\n\n",

--- a/resources/themes/atom/js/components/ArticleReactions.js
+++ b/resources/themes/atom/js/components/ArticleReactions.js
@@ -1,12 +1,10 @@
-import Alpine from "alpinejs";
-
 const ArticleReactions = {
     init() {
         document.addEventListener("alpine:init", () => this.startComponent());
     },
 
     startComponent() {
-        Alpine.data(
+        window.Alpine.data(
             "reactions",
             (myReactions = [], articleReactions = [], url = "") => ({
                 url,

--- a/resources/themes/atom/views/client/nitro.blade.php
+++ b/resources/themes/atom/views/client/nitro.blade.php
@@ -10,6 +10,8 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Condensed&display=swap" rel="stylesheet">
 
+    @livewireStyles
+    @livewireScriptConfig
     @vite(['resources/themes/' .  setting('theme') . '/css/app.css', 'resources/themes/' .  setting('theme') . '/js/app.js'], 'build')
 </head>
 

--- a/resources/themes/atom/views/layouts/app.blade.php
+++ b/resources/themes/atom/views/layouts/app.blade.php
@@ -19,6 +19,8 @@
     <script src="{{ asset('assets/js/tippy-bundle.umd.min.js') }}"></script>
     <link rel="stylesheet" href="{{ asset('assets/css/scale.min.css') }}"/>
 
+    @livewireStyles
+    @livewireScriptConfig
     @vite(['resources/themes/' .  setting('theme', 'atom') . '/css/app.css', 'resources/themes/' .  setting('theme') . '/js/app.js'], 'build')
     @stack('scripts')
     <x-turnstile.scripts />
@@ -103,7 +105,6 @@
     @endif
 
     <script defer src="{{ asset('assets/js/alpine-ui.js') }}"></script>
-    <script defer src="{{ asset('assets/js/alpine-focus.js') }}"></script>
 
     @stack('javascript')
     </body>

--- a/resources/themes/atom/views/layouts/guest.blade.php
+++ b/resources/themes/atom/views/layouts/guest.blade.php
@@ -13,6 +13,8 @@
     <!-- Fonts -->
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
+    @livewireStyles
+    @livewireScriptConfig
     @vite(['resources/themes/' .  setting('theme') . '/css/app.css', 'resources/themes/' .  setting('theme') . '/js/app.js'], 'build')
 </head>
 

--- a/resources/themes/atom/vite.config.js
+++ b/resources/themes/atom/vite.config.js
@@ -31,6 +31,7 @@ export default defineConfig({
     resolve: {
         alias: {
             "@": path.resolve(__dirname, "js/app.js"),
+            livewire: path.resolve(__dirname, "../../../vendor/livewire/livewire/dist/livewire.esm.js"),
         },
     },
     css: {

--- a/resources/themes/dusk/js/app.js
+++ b/resources/themes/dusk/js/app.js
@@ -13,9 +13,26 @@ import "../../../js/components/HomeManager.js";
 
 window.Alpine = Alpine;
 
-const startLivewire = () => Livewire.start();
+const livewireStartedKey = Symbol.for("atomcms.livewire.started");
+const startLivewire = () => {
+    if (window[livewireStartedKey]) {
+        return;
+    }
+
+    window[livewireStartedKey] = true;
+
+    try {
+        Livewire.start();
+    } catch (error) {
+        delete window[livewireStartedKey];
+        throw error;
+    }
+};
+
 if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", startLivewire, { once: true });
+    document.addEventListener("DOMContentLoaded", startLivewire, {
+        once: true,
+    });
 } else {
     startLivewire();
 }

--- a/resources/themes/dusk/js/app.js
+++ b/resources/themes/dusk/js/app.js
@@ -1,8 +1,7 @@
 import "./bootstrap";
 import "./external/flowbite";
 
-import Alpine from "alpinejs";
-import Focus from "@alpinejs/focus";
+import { Livewire, Alpine } from "livewire";
 
 import Swiper from "swiper";
 import { Navigation, Pagination } from "swiper/modules";
@@ -12,8 +11,14 @@ import "swiper/css/pagination";
 
 import "../../../js/components/HomeManager.js";
 
-Alpine.plugin(Focus);
-Alpine.start();
+window.Alpine = Alpine;
+
+const startLivewire = () => Livewire.start();
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", startLivewire, { once: true });
+} else {
+    startLivewire();
+}
 
 // Swiper Initialization
 document.addEventListener("DOMContentLoaded", function () {

--- a/resources/themes/dusk/js/components/ArticleReactions.js
+++ b/resources/themes/dusk/js/components/ArticleReactions.js
@@ -1,12 +1,10 @@
-import Alpine from "alpinejs";
-
 const ArticleReactions = {
     init() {
         document.addEventListener("alpine:init", () => this.startComponent());
     },
 
     startComponent() {
-        Alpine.data(
+        window.Alpine.data(
             "reactions",
             (myReactions = [], articleReactions = [], url = "") => ({
                 url,

--- a/resources/themes/dusk/views/client/nitro.blade.php
+++ b/resources/themes/dusk/views/client/nitro.blade.php
@@ -10,6 +10,8 @@
 
     <link href="https://fonts.googleapis.com/css2?family=Ubuntu+Condensed&display=swap" rel="stylesheet">
 
+    @livewireStyles
+    @livewireScriptConfig
     @vite(['resources/themes/' .  setting('theme') . '/css/app.css', 'resources/themes/' .  setting('theme') . '/js/app.js'], 'build')
 </head>
 

--- a/resources/themes/dusk/views/layouts/app.blade.php
+++ b/resources/themes/dusk/views/layouts/app.blade.php
@@ -12,6 +12,8 @@
         <!-- Fonts -->
         <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap">
 
+        @livewireStyles
+        @livewireScriptConfig
         @vite(['resources/themes/' .  setting('theme', 'dusk') . '/css/app.css', 'resources/themes/' .  setting('theme') . '/js/app.js'], 'build')
         <x-turnstile.scripts />
 

--- a/resources/themes/dusk/vite.config.js
+++ b/resources/themes/dusk/vite.config.js
@@ -31,6 +31,7 @@ export default defineConfig({
     resolve: {
         alias: {
             "@": path.resolve(__dirname, "js/app.js"),
+            livewire: path.resolve(__dirname, "../../../vendor/livewire/livewire/dist/livewire.esm.js"),
         },
     },
     css: {

--- a/resources/views/components/messages/flash-messages.blade.php
+++ b/resources/views/components/messages/flash-messages.blade.php
@@ -140,13 +140,5 @@
                 this.toasts = this.toasts.filter((toast) => toast.id !== id);
             },
         });
-
-        document.addEventListener('livewire:init', () => {
-            Livewire.on('toast', (payload) => {
-                const detail = Array.isArray(payload) ? payload[0] : payload;
-
-                window.toast(detail?.title ?? '', detail?.icon ?? 'success');
-            });
-        });
     })();
 </script>

--- a/resources/views/maintenance.blade.php
+++ b/resources/views/maintenance.blade.php
@@ -8,6 +8,8 @@
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
     <title>{{ setting('hotel_name') }} - {{ __('Maintenance') }}</title>
 
+    @livewireStyles
+    @livewireScriptConfig
     @vite(['resources/themes/' .  setting('theme') . '/css/app.css', 'resources/themes/' .  setting('theme') . '/js/app.js'], 'build')
 </head>
 


### PR DESCRIPTION
The auto-injected Livewire runtime only calls `Livewire.start()` on
`DOMContentLoaded`, which never re-fires during a Turbolinks body swap. As a
result, the first comment submit after a Turbolinks navigation fell back to a
native form GET and saved nothing. A separate toast bridge also re-forwarded
each Livewire `toast` event into a second window event, showing two toasts.

- Import Livewire's ESM runtime and bundled Alpine into both theme entry points
  through a `livewire` Vite alias.
- Start Livewire ready-state-safely and guard startup with a shared global symbol,
  preventing duplicate initialization if a theme bundle is evaluated more than
  once. Clear the guard if startup fails so initialization can be retried.
- Register both `HomeManager` and `ArticleReactions` through `window.Alpine` on
  `alpine:init`, ensuring every component uses Livewire's bundled Alpine instance.
- Add `@livewireScriptConfig` and `@livewireStyles` to every full-page template
  that loads a theme bundle, providing the bundled runtime's configuration while
  suppressing Livewire's automatically injected runtime.
- Remove the standalone `alpinejs` and `@alpinejs/focus` dependencies, associated
  lockfile entries, and the external `alpine-focus.js` include because Livewire
  already bundles Alpine and the Focus plugin.
- Remove the redundant `Livewire.on('toast')` bridge; the existing
  `x-on:toast.window` listener already receives the bubbled event.