### PR TITLE
fix(captcha): gate turnstile validation on the website setting

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -8,6 +8,7 @@ use App\Jobs\SendRegisteredUserWebhook;
 use App\Models\Miscellaneous\WebsiteBetaCode;
 use App\Models\User;
 use App\Rules\BetaCodeRule;
+use App\Rules\CloudflareTurnstileRule;
 use App\Rules\GoogleRecaptchaRule;
 use App\Rules\WebsiteWordfilterRule;
 use App\Services\Auth\RegistrationMutex;
@@ -17,7 +18,6 @@ use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
-use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class CreateNewUser implements CreatesNewUsers
 {
@@ -183,7 +183,7 @@ class CreateNewUser implements CreatesNewUsers
             'referral_code' => ['nullable', 'string', 'max:255'],
             'terms' => ['required', 'accepted'],
             'g-recaptcha-response' => ['sometimes', 'string', new GoogleRecaptchaRule],
-            'cf-turnstile-response' => [app(Turnstile::class)],
+            'cf-turnstile-response' => [new CloudflareTurnstileRule],
         ];
 
         $messages = [

--- a/app/Http/Requests/AccountSettingsFormRequest.php
+++ b/app/Http/Requests/AccountSettingsFormRequest.php
@@ -4,13 +4,13 @@ namespace App\Http\Requests;
 
 use App\Emulator\Emulator;
 use App\Models\User;
+use App\Rules\CloudflareTurnstileRule;
 use App\Rules\CurrentPasswordRule;
 use App\Rules\GoogleRecaptchaRule;
 use App\Rules\WebsiteWordfilterRule;
 use App\Support\AuthenticatedUser;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class AccountSettingsFormRequest extends FormRequest
 {
@@ -23,7 +23,7 @@ class AccountSettingsFormRequest extends FormRequest
             'mail' => ['required', 'email', 'max:' . Emulator::constraints()->emailLength, Rule::unique('users')->ignore($user->id), new WebsiteWordfilterRule],
             'motto' => ['nullable', 'string', 'max:' . Emulator::constraints()->mottoLength, new WebsiteWordfilterRule],
             'g-recaptcha-response' => [new GoogleRecaptchaRule],
-            'cf-turnstile-response' => [app(Turnstile::class)],
+            'cf-turnstile-response' => [new CloudflareTurnstileRule],
         ];
 
         // Re-authenticate before a security-sensitive email change.

--- a/app/Http/Requests/PasswordSettingsFormRequest.php
+++ b/app/Http/Requests/PasswordSettingsFormRequest.php
@@ -3,10 +3,10 @@
 namespace App\Http\Requests;
 
 use App\Actions\Fortify\Rules\PasswordValidationRules;
+use App\Rules\CloudflareTurnstileRule;
 use App\Rules\CurrentPasswordRule;
 use App\Rules\GoogleRecaptchaRule;
 use Illuminate\Foundation\Http\FormRequest;
-use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class PasswordSettingsFormRequest extends FormRequest
 {
@@ -19,7 +19,7 @@ class PasswordSettingsFormRequest extends FormRequest
             'current_password' => ['required', 'string', new CurrentPasswordRule],
             'password' => $this->passwordRules(),
             'g-recaptcha-response' => [new GoogleRecaptchaRule],
-            'cf-turnstile-response' => [app(Turnstile::class)],
+            'cf-turnstile-response' => [new CloudflareTurnstileRule],
         ];
     }
 }

--- a/app/Http/Requests/RegisterFormRequest.php
+++ b/app/Http/Requests/RegisterFormRequest.php
@@ -4,10 +4,10 @@ namespace App\Http\Requests;
 
 use App\Actions\Fortify\Rules\PasswordValidationRules;
 use App\Emulator\Emulator;
+use App\Rules\CloudflareTurnstileRule;
 use App\Rules\GoogleRecaptchaRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class RegisterFormRequest extends FormRequest
 {
@@ -24,7 +24,7 @@ class RegisterFormRequest extends FormRequest
             'password' => $this->passwordRules(),
             'terms' => ['required', 'accepted'],
             'g-recaptcha-response' => [new GoogleRecaptchaRule],
-            'cf-turnstile-response' => [app(Turnstile::class)],
+            'cf-turnstile-response' => [new CloudflareTurnstileRule],
         ];
     }
 

--- a/app/Http/Requests/ShopVoucherFormRequest.php
+++ b/app/Http/Requests/ShopVoucherFormRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\CloudflareTurnstileRule;
 use App\Rules\GoogleRecaptchaRule;
 use Illuminate\Foundation\Http\FormRequest;
-use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class ShopVoucherFormRequest extends FormRequest
 {
@@ -14,7 +14,7 @@ class ShopVoucherFormRequest extends FormRequest
         return [
             'code' => ['required', 'string', 'max:64'],
             'g-recaptcha-response' => [new GoogleRecaptchaRule],
-            'cf-turnstile-response' => [app(Turnstile::class)],
+            'cf-turnstile-response' => [new CloudflareTurnstileRule],
         ];
     }
 }

--- a/app/Http/Requests/StaffApplicationFormRequest.php
+++ b/app/Http/Requests/StaffApplicationFormRequest.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Requests;
 
+use App\Rules\CloudflareTurnstileRule;
 use App\Rules\GoogleRecaptchaRule;
 use Illuminate\Foundation\Http\FormRequest;
-use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
 
 class StaffApplicationFormRequest extends FormRequest
 {
@@ -14,7 +14,7 @@ class StaffApplicationFormRequest extends FormRequest
         return [
             'content' => ['required', 'string', 'min:10', 'max:5000'],
             'g-recaptcha-response' => [new GoogleRecaptchaRule],
-            'cf-turnstile-response' => [app(Turnstile::class)],
+            'cf-turnstile-response' => [new CloudflareTurnstileRule],
         ];
     }
 

--- a/app/Rules/CloudflareTurnstileRule.php
+++ b/app/Rules/CloudflareTurnstileRule.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Log;
+use RyanChandler\LaravelCloudflareTurnstile\Rules\Turnstile;
+
+class CloudflareTurnstileRule implements ValidationRule
+{
+    /**
+     * Runs even when the field is absent, so a submission that skipped the
+     * widget fails validation instead of erroring inside the verify call.
+     *
+     * @var bool
+     */
+    public $implicit = true;
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        // Only enforced when enabled through website_settings.
+        if (! (int) setting('cloudflare_turnstile_enabled')) {
+            return;
+        }
+
+        // An enabled toggle without credentials would lock everyone out of
+        // the form, so treat it as disabled and tell the operator instead.
+        if (blank(config('turnstile.turnstile_secret_key'))) {
+            Log::warning('Cloudflare Turnstile is enabled in website_settings but TURNSTILE_SECRET_KEY is not configured; skipping captcha verification.');
+
+            return;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            $fail(__('Please verify that you are not a robot.'));
+
+            return;
+        }
+
+        try {
+            app(Turnstile::class)->validate($attribute, $value, $fail);
+        } catch (ConnectionException) {
+            $fail(__('The captcha could not be verified. Please try again.'));
+        }
+    }
+}

--- a/database/seeders/WebsiteSettingsSeeder.php
+++ b/database/seeders/WebsiteSettingsSeeder.php
@@ -182,7 +182,7 @@ class WebsiteSettingsSeeder extends Seeder
             ],
             [
                 'key' => 'cloudflare_turnstile_enabled',
-                'value' => '1',
+                'value' => '0',
                 'comment' => 'Determines whether cloudflare turnstile is enabled or not - Do not enable if google recaptche is enabled',
             ],
             [

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -131,3 +131,34 @@ test('the register routes follow the fortify naming convention', function () {
 
     $this->get(route('register'))->assertOk();
 });
+
+test('an enabled turnstile rejects a missing captcha token with a validation error', function () {
+    installHotel();
+    setSetting('cloudflare_turnstile_enabled', '1');
+    config()->set('turnstile.turnstile_secret_key', 'test-secret');
+
+    register()->assertSessionHasErrors('cf-turnstile-response');
+
+    $this->assertGuest();
+
+    expect(User::where('username', 'Tester')->exists())->toBeFalse();
+});
+
+test('a disabled turnstile never blocks registration', function () {
+    installHotel();
+    setSetting('cloudflare_turnstile_enabled', '0');
+
+    register()->assertRedirect(RouteServiceProvider::HOME);
+
+    $this->assertAuthenticated();
+});
+
+test('an enabled turnstile without configured keys does not block registration', function () {
+    installHotel();
+    setSetting('cloudflare_turnstile_enabled', '1');
+    config()->set('turnstile.turnstile_secret_key', null);
+
+    register()->assertRedirect(RouteServiceProvider::HOME);
+
+    $this->assertAuthenticated();
+});


### PR DESCRIPTION
- Registering without completing the Turnstile widget now returns a proper validation message instead of a 500
- New CloudflareTurnstileRule only enforces the captcha when cloudflare_turnstile_enabled is set in website_settings, and then treats a missing token as a failure instead of silently skipping it
- An enabled toggle without a configured TURNSTILE_SECRET_KEY logs a warning and skips verification, so misconfigured hotels cannot lock out registration
- Seed cloudflare_turnstile_enabled as disabled, since fresh installs have no Turnstile keys
- Cover the enabled, disabled and keyless paths in the registration tests