### PR TITLE
feat(database): reclaim colliding schema during migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,7 +83,8 @@ GOOGLE_RECAPTCHA_SECRET_KEY=
 TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 
-# If set to true, Atom will rename any colliding table names when migration the first time around
+# If set to true, migrations rename colliding tables and columns (including their
+# indexes and foreign keys) to old_<timestamp>_<name> so Atom's schema can take their place
 RENAME_COLLIDING_TABLES=false
 
 # Flash client settings

--- a/app/Database/CollisionAwareMariaDbConnection.php
+++ b/app/Database/CollisionAwareMariaDbConnection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Database;
+
+use App\Database\Schema\CollisionAwareMariaDbBuilder;
+use Illuminate\Database\MariaDbConnection;
+
+class CollisionAwareMariaDbConnection extends MariaDbConnection
+{
+    public function getSchemaBuilder()
+    {
+        if (is_null($this->schemaGrammar)) {
+            $this->useDefaultSchemaGrammar();
+        }
+
+        return new CollisionAwareMariaDbBuilder($this);
+    }
+}

--- a/app/Database/CollisionAwareMySqlConnection.php
+++ b/app/Database/CollisionAwareMySqlConnection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Database;
+
+use App\Database\Schema\CollisionAwareMySqlBuilder;
+use Illuminate\Database\MySqlConnection;
+
+class CollisionAwareMySqlConnection extends MySqlConnection
+{
+    public function getSchemaBuilder()
+    {
+        if (is_null($this->schemaGrammar)) {
+            $this->useDefaultSchemaGrammar();
+        }
+
+        return new CollisionAwareMySqlBuilder($this);
+    }
+}

--- a/app/Database/Schema/CollisionAwareMariaDbBuilder.php
+++ b/app/Database/Schema/CollisionAwareMariaDbBuilder.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Database\Schema;
+
+use Illuminate\Database\Schema\MariaDbBuilder;
+
+class CollisionAwareMariaDbBuilder extends MariaDbBuilder
+{
+    use ReclaimsCollidingSchema;
+}

--- a/app/Database/Schema/CollisionAwareMySqlBuilder.php
+++ b/app/Database/Schema/CollisionAwareMySqlBuilder.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Database\Schema;
+
+use Illuminate\Database\Schema\MySqlBuilder;
+
+class CollisionAwareMySqlBuilder extends MySqlBuilder
+{
+    use ReclaimsCollidingSchema;
+}

--- a/app/Database/Schema/ReclaimsCollidingSchema.php
+++ b/app/Database/Schema/ReclaimsCollidingSchema.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Database\Schema;
+
+use Closure;
+use Illuminate\Database\Schema\ColumnDefinition;
+use RuntimeException;
+
+/**
+ * Intercepts schema changes that would collide with tables or columns left
+ * behind by the emulator database or a previous CMS. With the rename flag on
+ * the collision is moved aside as old_<timestamp>_<name>; with it off the
+ * raw SQL error is replaced by an actionable message.
+ */
+trait ReclaimsCollidingSchema
+{
+    public function create($table, Closure $callback)
+    {
+        if ($this->hasTable($table)) {
+            $this->guardCollision(sprintf(
+                "Table '%s' already exists, usually left behind by your emulator database or a previous CMS. "
+                . "Set RENAME_COLLIDING_TABLES=true in your .env to let Atom move it aside as '%s%s', "
+                . 'or remove it manually, then rerun the migration.',
+                $table,
+                SchemaReclaimer::prefix(),
+                $table,
+            ));
+
+            (new SchemaReclaimer($this->connection))->reclaimTable($table);
+        }
+
+        parent::create($table, $callback);
+    }
+
+    public function table($table, Closure $callback)
+    {
+        $blueprint = $this->createBlueprint($table, $callback);
+
+        $added = array_map(
+            fn (ColumnDefinition $column) => (string) $column->get('name'),
+            array_values($blueprint->getAddedColumns()),
+        );
+
+        if ($added !== [] && $this->hasTable($table)) {
+            $colliding = array_values(array_intersect($added, $this->getColumnListing($table)));
+
+            if ($colliding !== []) {
+                $this->guardCollision(sprintf(
+                    "Column '%s.%s' already exists, usually left behind by your emulator database or a previous CMS. "
+                    . "Set RENAME_COLLIDING_TABLES=true in your .env to let Atom move it aside as '%s%s', "
+                    . 'or remove it manually, then rerun the migration.',
+                    $table,
+                    $colliding[0],
+                    SchemaReclaimer::prefix(),
+                    $colliding[0],
+                ));
+
+                (new SchemaReclaimer($this->connection))->reclaimColumns($table, $colliding);
+            }
+        }
+
+        $this->build($blueprint);
+    }
+
+    private function guardCollision(string $message): void
+    {
+        if (! SchemaReclaimer::enabled()) {
+            throw new RuntimeException($message);
+        }
+    }
+}

--- a/app/Database/Schema/SchemaReclaimer.php
+++ b/app/Database/Schema/SchemaReclaimer.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace App\Database\Schema;
+
+use Illuminate\Database\Connection;
+use Illuminate\Support\Collection;
+
+/**
+ * Moves colliding tables and columns aside as old_<timestamp>_<name> so the
+ * CMS schema can claim the canonical names.
+ *
+ * MySQL and MariaDB carry data, indexes and foreign keys along when a table
+ * or column is renamed, but the index and constraint names themselves stay
+ * behind. Foreign key names are schema-unique, so they are renamed explicitly
+ * (drop + re-add) to free the conventional names Laravel would generate for
+ * the replacement schema.
+ */
+class SchemaReclaimer
+{
+    /**
+     * One prefix per process, so a single migrate run groups its renames
+     * under the same timestamp.
+     */
+    private static ?string $prefix = null;
+
+    public function __construct(private readonly Connection $connection) {}
+
+    public static function enabled(): bool
+    {
+        return (bool) config('habbo.migrations.rename_tables');
+    }
+
+    public static function prefix(): string
+    {
+        return self::$prefix ??= sprintf('old_%d_', now()->getTimestamp());
+    }
+
+    public function reclaimTable(string $table): void
+    {
+        // Index names are table-scoped, so only the schema-unique foreign
+        // key names need to move aside with the table.
+        $this->renameForeignKeys($table);
+
+        $this->connection->statement(sprintf(
+            'RENAME TABLE %s TO %s',
+            $this->wrap($this->prefixed($table)),
+            $this->wrap($this->renamed($this->prefixed($table))),
+        ));
+    }
+
+    /**
+     * @param  list<string>  $columns
+     */
+    public function reclaimColumns(string $table, array $columns): void
+    {
+        foreach ($columns as $column) {
+            // The re-added constraints and renamed indexes stay attached to
+            // the column and follow it through the rename below.
+            $this->renameForeignKeys($table, $column);
+            $this->renameIndexes($table, $column);
+
+            $this->connection->statement(sprintf(
+                'ALTER TABLE %s RENAME COLUMN %s TO %s',
+                $this->wrap($this->prefixed($table)),
+                $this->wrap($column),
+                $this->wrap($this->renamed($column)),
+            ));
+        }
+    }
+
+    private function renameForeignKeys(string $table, ?string $column = null): void
+    {
+        foreach ($this->foreignKeys($table) as $name => $parts) {
+            $first = $parts->first();
+
+            if ($first === null) {
+                continue;
+            }
+
+            $columns = $parts->pluck('column_name');
+
+            if ($column !== null && ! $columns->contains($column)) {
+                continue;
+            }
+
+            $this->connection->statement(sprintf(
+                'ALTER TABLE %s DROP FOREIGN KEY %s',
+                $this->wrap($this->prefixed($table)),
+                $this->wrap($name),
+            ));
+
+            $this->connection->statement(sprintf(
+                'ALTER TABLE %s ADD CONSTRAINT %s FOREIGN KEY (%s) REFERENCES %s (%s) ON DELETE %s ON UPDATE %s',
+                $this->wrap($this->prefixed($table)),
+                $this->wrap($this->renamed($name)),
+                $columns->map(fn (string $c) => $this->wrap($c))->implode(', '),
+                $this->wrap($first->referenced_table),
+                $parts->pluck('referenced_column')->map(fn (string $c) => $this->wrap($c))->implode(', '),
+                $first->delete_rule,
+                $first->update_rule,
+            ));
+        }
+    }
+
+    private function renameIndexes(string $table, string $column): void
+    {
+        $indexes = $this->connection->select(
+            'SELECT DISTINCT INDEX_NAME AS index_name
+                FROM information_schema.STATISTICS
+                WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = ?
+                AND COLUMN_NAME = ?
+                AND INDEX_NAME <> ?',
+            [$this->prefixed($table), $column, 'PRIMARY'],
+        );
+
+        foreach ($indexes as $index) {
+            $this->connection->statement(sprintf(
+                'ALTER TABLE %s RENAME INDEX %s TO %s',
+                $this->wrap($this->prefixed($table)),
+                $this->wrap($index->index_name),
+                $this->wrap($this->renamed($index->index_name)),
+            ));
+        }
+    }
+
+    /**
+     * The table's outgoing foreign keys, keyed by constraint name and ordered
+     * by column position so composite keys re-assemble correctly.
+     *
+     * @return Collection<array-key, Collection<int, object{constraint_name: string, column_name: string, referenced_table: string, referenced_column: string, delete_rule: string, update_rule: string}>>
+     */
+    private function foreignKeys(string $table): Collection
+    {
+        /** @var list<object{constraint_name: string, column_name: string, referenced_table: string, referenced_column: string, delete_rule: string, update_rule: string}> $rows */
+        $rows = $this->connection->select(
+            'SELECT kcu.CONSTRAINT_NAME AS constraint_name,
+                    kcu.COLUMN_NAME AS column_name,
+                    kcu.REFERENCED_TABLE_NAME AS referenced_table,
+                    kcu.REFERENCED_COLUMN_NAME AS referenced_column,
+                    rc.DELETE_RULE AS delete_rule,
+                    rc.UPDATE_RULE AS update_rule
+                FROM information_schema.KEY_COLUMN_USAGE kcu
+                JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+                    ON rc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
+                    AND rc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+                    AND rc.TABLE_NAME = kcu.TABLE_NAME
+                WHERE kcu.CONSTRAINT_SCHEMA = DATABASE()
+                AND kcu.TABLE_NAME = ?
+                AND kcu.REFERENCED_TABLE_NAME IS NOT NULL
+                ORDER BY kcu.CONSTRAINT_NAME, kcu.ORDINAL_POSITION',
+            [$this->prefixed($table)],
+        );
+
+        return collect($rows)->groupBy('constraint_name');
+    }
+
+    /**
+     * The reclaimed name, kept within MySQL's 64 character identifier limit
+     * with a stable hash suffix when truncation is unavoidable.
+     */
+    private function renamed(string $name): string
+    {
+        $renamed = self::prefix() . $name;
+
+        if (strlen($renamed) > 64) {
+            $renamed = substr($renamed, 0, 55) . '_' . substr(md5($name), 0, 8);
+        }
+
+        return $renamed;
+    }
+
+    private function prefixed(string $table): string
+    {
+        return $this->connection->getTablePrefix() . $table;
+    }
+
+    private function wrap(string $identifier): string
+    {
+        return '`' . str_replace('`', '``', $identifier) . '`';
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use App\Contracts\PaypalGateway;
+use App\Database\CollisionAwareMariaDbConnection;
+use App\Database\CollisionAwareMySqlConnection;
 use App\Models\WebsiteDrawBadge;
 use App\Observers\WebsiteDrawBadgeObserver;
 use App\Services\HousekeepingPermissionsService;
@@ -14,6 +16,7 @@ use App\Services\ViteService;
 use Filament\Tables\Table;
 use GuzzleHttp\Client as HttpClient;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Vite;
 use Illuminate\Support\Facades\URL;
@@ -29,6 +32,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        // Collision-aware connections rename tables and columns left behind
+        // by the emulator database out of the way during migrations, or turn
+        // the raw "already exists" SQL errors into actionable ones.
+        Connection::resolverFor('mysql', fn ($connection, $database, $prefix, $config) => new CollisionAwareMySqlConnection($connection, $database, $prefix, $config));
+        Connection::resolverFor('mariadb', fn ($connection, $database, $prefix, $config) => new CollisionAwareMariaDbConnection($connection, $database, $prefix, $config));
+
         // Scoped per request so a webhook that verifies and captures reuses a
         // single gateway (and therefore a single PayPal client and token).
         $this->app->scoped(PaypalGateway::class, SrmklivePaypalGateway::class);

--- a/config/habbo.php
+++ b/config/habbo.php
@@ -31,7 +31,10 @@ return [
     ],
 
     'migrations' => [
-        // Only set this to true in the .env file if your CERTAIN that you want to rename coliding table names
+        // When enabled, migrations move colliding tables and columns (plus
+        // their indexes and foreign keys) aside as old_<timestamp>_<name> so
+        // the CMS schema can take the canonical names. Only enable it if you
+        // are certain the colliding data is safe to archive.
         'rename_tables' => env('RENAME_COLLIDING_TABLES', false),
     ],
 

--- a/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -11,10 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('password_resets')) {
-            Schema::rename('password_resets', sprintf('password_resets_%s', time()));
-        }
-
         Schema::create('password_resets', function (Blueprint $table) {
             $table->string('email')->index();
             $table->string('token');

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -11,10 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('failed_jobs')) {
-            Schema::rename('failed_jobs', sprintf('failed_jobs_%s', time()));
-        }
-
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->id();
             $table->string('uuid')->unique();

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -11,10 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('personal_access_tokens')) {
-            Schema::rename('personal_access_tokens', sprintf('personal_access_tokens_%s', time()));
-        }
-
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
             $table->morphs('tokenable');

--- a/database/migrations/2022_08_01_181153_create_activity_log_table.php
+++ b/database/migrations/2022_08_01_181153_create_activity_log_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable(config('activitylog.table_name'))) {
-            Schema::rename(config('activitylog.table_name'), sprintf('%s_%s', config('activitylog.table_name'), time()));
-        }
-
         Schema::connection(config('activitylog.database_connection'))->create(config('activitylog.table_name'), function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->string('log_name')->nullable();

--- a/database/migrations/2022_08_01_204744_create_table_website_settings.php
+++ b/database/migrations/2022_08_01_204744_create_table_website_settings.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_settings')) {
-            Schema::rename('website_settings', sprintf('website_settings_%s', time()));
-        }
-
         Schema::create('website_settings', function (Blueprint $table) {
             $table->id();
             $table->string('key')->unique();

--- a/database/migrations/2022_08_01_225834_create_website_articles_table.php
+++ b/database/migrations/2022_08_01_225834_create_website_articles_table.php
@@ -9,11 +9,6 @@ return new class extends Migration
     public function up(): void
     {
 
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_articles')) {
-            dropForeignKeyIfExists('website_articles', 'user_id');
-            Schema::rename('website_articles', sprintf('website_articles_%s', time()));
-        }
-
         Schema::create('website_articles', function (Blueprint $table) {
             $table->id();
             $table->string('slug')->unique();

--- a/database/migrations/2022_08_04_171615_create_website_languages_table.php
+++ b/database/migrations/2022_08_04_171615_create_website_languages_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_languages')) {
-            Schema::rename('website_languages', sprintf('website_languages_%s', time()));
-        }
-
         Schema::create('website_languages', function (Blueprint $table) {
             $table->id();
             $table->string('country_code', 8)->unique();

--- a/database/migrations/2022_08_06_022514_create_user_referrals_table.php
+++ b/database/migrations/2022_08_06_022514_create_user_referrals_table.php
@@ -8,11 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('user_referrals')) {
-            dropForeignKeyIfExists('user_referrals', 'user_id');
-            Schema::rename('user_referrals', sprintf('user_referrals_%s', time()));
-        }
-
         Schema::create('user_referrals', function (Blueprint $table) {
             $table->id();
             $table->integer('user_id');

--- a/database/migrations/2022_08_06_022636_create_referrals_table.php
+++ b/database/migrations/2022_08_06_022636_create_referrals_table.php
@@ -8,11 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('referrals')) {
-            dropForeignKeyIfExists('referrals', 'user_id');
-            Schema::rename('referrals', sprintf('referrals_%s', time()));
-        }
-
         Schema::create('referrals', function (Blueprint $table) {
             $table->id();
             $table->integer('user_id')->index();

--- a/database/migrations/2022_08_06_022745_create_claimed_referral_logs_table.php
+++ b/database/migrations/2022_08_06_022745_create_claimed_referral_logs_table.php
@@ -8,11 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('claimed_referral_logs')) {
-            dropForeignKeyIfExists('claimed_referral_logs', 'user_id');
-            Schema::rename('claimed_referral_logs', sprintf('claimed_referral_logs_%s', time()));
-        }
-
         Schema::create('claimed_referral_logs', function (Blueprint $table) {
             $table->id();
             $table->integer('user_id')->index();

--- a/database/migrations/2022_08_26_224418_create_website_ip_whitelist_table.php
+++ b/database/migrations/2022_08_26_224418_create_website_ip_whitelist_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_ip_whitelist')) {
-            Schema::rename('website_ip_whitelist', sprintf('website_ip_whitelist_%s', time()));
-        }
-
         Schema::create('website_ip_whitelist', function (Blueprint $table) {
             $table->id();
             $table->string('ip_address');

--- a/database/migrations/2022_08_26_224659_create_website_ip_blacklist_table.php
+++ b/database/migrations/2022_08_26_224659_create_website_ip_blacklist_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_ip_blacklist')) {
-            Schema::rename('website_ip_blacklist', sprintf('website_ip_blacklist_%s', time()));
-        }
-
         Schema::create('website_ip_blacklist', function (Blueprint $table) {
             $table->id();
             $table->string('ip_address');

--- a/database/migrations/2022_08_26_225952_create_website_permissions_table.php
+++ b/database/migrations/2022_08_26_225952_create_website_permissions_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_permissions')) {
-            Schema::rename('website_permissions', sprintf('website_permissions_%s', time()));
-        }
-
         Schema::create('website_permissions', function (Blueprint $table) {
             $table->id();
             $table->string('key')->unique();

--- a/database/migrations/2022_09_26_123543_add_website_article_reactions_table.php
+++ b/database/migrations/2022_09_26_123543_add_website_article_reactions_table.php
@@ -11,11 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_article_reactions')) {
-            dropForeignKeyIfExists('website_article_reactions', 'article_id');
-            Schema::rename('website_article_reactions', sprintf('website_article_reactions_%s', time()));
-        }
-
         Schema::create('website_article_reactions', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('user_id');

--- a/database/migrations/2022_10_01_204009_create_user_sessions_logs_table.php
+++ b/database/migrations/2022_10_01_204009_create_user_sessions_logs_table.php
@@ -11,10 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('users_session_logs')) {
-            Schema::rename('users_session_logs', sprintf('users_session_logs_%s', time()));
-        }
-
         Schema::create('users_session_logs', function (Blueprint $table) {
             $table->id();
 

--- a/database/migrations/2022_10_11_135920_create_sessions_table.php
+++ b/database/migrations/2022_10_11_135920_create_sessions_table.php
@@ -11,11 +11,6 @@ return new class extends Migration
      */
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('sessions')) {
-            dropForeignKeyIfExists('sessions', 'user_id');
-            Schema::rename('sessions', sprintf('sessions_%s', time()));
-        }
-
         Schema::create('sessions', function (Blueprint $table) {
             $table->string('id')->primary();
             $table->foreignId('user_id')->nullable()->index();

--- a/database/migrations/2022_11_12_231917_create_website_wordfilter_table.php
+++ b/database/migrations/2022_11_12_231917_create_website_wordfilter_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_wordfilter')) {
-            Schema::rename('website_wordfilter', sprintf('website_wordfilter_%s', time()));
-        }
-
         Schema::create('website_wordfilter', function (Blueprint $table) {
             $table->id();
             $table->string('word')->unique();

--- a/database/migrations/2022_11_15_190549_create_website_beta_codes_table.php
+++ b/database/migrations/2022_11_15_190549_create_website_beta_codes_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_beta_codes')) {
-            Schema::rename('website_beta_codes', sprintf('website_beta_codes_%s', time()));
-        }
-
         Schema::create('website_beta_codes', function (Blueprint $table) {
             $table->id();
             $table->string('code')->unique();

--- a/database/migrations/2022_11_29_145238_create_website_teams_table.php
+++ b/database/migrations/2022_11_29_145238_create_website_teams_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_teams')) {
-            Schema::rename('website_teams', sprintf('website_teams_%s', time()));
-        }
-
         Schema::create('website_teams', function (Blueprint $table) {
             $table->id();
             $table->string('rank_name')->unique();

--- a/database/migrations/2022_12_03_140445_create_website_staff_applications_table.php
+++ b/database/migrations/2022_12_03_140445_create_website_staff_applications_table.php
@@ -8,12 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_staff_applications')) {
-            dropForeignKeyIfExists('website_staff_applications', 'user_id');
-            dropForeignKeyIfExists('website_staff_applications', 'rank_id');
-            Schema::rename('website_staff_applications', sprintf('website_staff_applications_%s', time()));
-        }
-
         Schema::create('website_staff_applications', function (Blueprint $table) {
             $table->id();
             $table->integer('user_id');

--- a/database/migrations/2022_12_06_233823_create_website_open_positions_table.php
+++ b/database/migrations/2022_12_06_233823_create_website_open_positions_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_open_positions')) {
-            Schema::rename('website_open_positions', sprintf('website_open_positions_%s', time()));
-        }
-
         Schema::create('website_open_positions', function (Blueprint $table) {
             $table->id();
             $table->integer('permission_id');

--- a/database/migrations/2023_01_08_134509_create_website_article_comments_table.php
+++ b/database/migrations/2023_01_08_134509_create_website_article_comments_table.php
@@ -8,12 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_article_comments')) {
-            dropForeignKeyIfExists('website_article_comments', 'article_id');
-            dropForeignKeyIfExists('website_article_comments', 'user_id');
-            Schema::rename('website_article_comments', sprintf('website_article_comments_%s', time()));
-        }
-
         Schema::create('website_article_comments', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('article_id');

--- a/database/migrations/2023_01_11_211401_create_website_rare_value_categories_table.php
+++ b/database/migrations/2023_01_11_211401_create_website_rare_value_categories_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_rare_value_categories')) {
-            Schema::rename('website_rare_value_categories', sprintf('website_rare_value_categories_%s', time()));
-        }
-
         Schema::create('website_rare_value_categories', function (Blueprint $table) {
             $table->id();
             $table->string('name')->unique();

--- a/database/migrations/2023_01_11_211508_create_website_rare_values_table.php
+++ b/database/migrations/2023_01_11_211508_create_website_rare_values_table.php
@@ -8,11 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_rare_values')) {
-            dropForeignKeyIfExists('website_rare_values', 'category_id');
-            Schema::rename('website_rare_values', sprintf('website_rare_values_%s', time()));
-        }
-
         Schema::create('website_rare_values', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('category_id');

--- a/database/migrations/2023_01_15_144949_create_website_rule_categories_table.php
+++ b/database/migrations/2023_01_15_144949_create_website_rule_categories_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_rule_categories')) {
-            Schema::rename('website_rule_categories', sprintf('website_rule_categories_%s', time()));
-        }
-
         Schema::create('website_rule_categories', function (Blueprint $table) {
             $table->id();
 

--- a/database/migrations/2023_01_15_145015_create_website_rules_table.php
+++ b/database/migrations/2023_01_15_145015_create_website_rules_table.php
@@ -8,11 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_rules')) {
-            dropForeignKeyIfExists('website_rules', 'category_id');
-            Schema::rename('website_rules', sprintf('website_rules_%s', time()));
-        }
-
         Schema::create('website_rules', function (Blueprint $table) {
             $table->id();
 

--- a/database/migrations/2023_04_04_212429_create_website_installation_table.php
+++ b/database/migrations/2023_04_04_212429_create_website_installation_table.php
@@ -8,10 +8,6 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (config('habbo.migrations.rename_tables') && Schema::hasTable('website_installation')) {
-            Schema::rename('website_installation', sprintf('website_installation_%s', time()));
-        }
-
         Schema::create('website_installation', function (Blueprint $table) {
             $table->id();
 

--- a/tests/Feature/Misc/SchemaCollisionTest.php
+++ b/tests/Feature/Misc/SchemaCollisionTest.php
@@ -1,0 +1,178 @@
+<?php
+
+use App\Database\Schema\SchemaReclaimer;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Schema\Builder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * DDL commits the transaction RefreshDatabase wraps each test in, so all
+ * schema work here goes through a clone of the default connection that the
+ * test transaction does not manage, and every scratch table is dropped
+ * explicitly.
+ */
+function reclaimConnection(): Connection
+{
+    return DB::connection('reclaim_test');
+}
+
+function reclaimSchema(): Builder
+{
+    return Schema::connection('reclaim_test');
+}
+
+function dropReclaimScratch(): void
+{
+    $connection = reclaimConnection();
+
+    $tables = $connection->select(
+        "SELECT TABLE_NAME AS name FROM information_schema.TABLES
+            WHERE TABLE_SCHEMA = DATABASE()
+            AND (TABLE_NAME LIKE 'reclaim\\_%' OR TABLE_NAME LIKE 'old\\_%\\_reclaim\\_%')",
+    );
+
+    $connection->statement('SET FOREIGN_KEY_CHECKS=0');
+
+    foreach ($tables as $table) {
+        $connection->statement(sprintf('DROP TABLE IF EXISTS `%s`', $table->name));
+    }
+
+    $connection->statement('SET FOREIGN_KEY_CHECKS=1');
+}
+
+beforeEach(function () {
+    config()->set(
+        'database.connections.reclaim_test',
+        config('database.connections.' . config('database.default')),
+    );
+
+    dropReclaimScratch();
+});
+
+afterEach(function () {
+    dropReclaimScratch();
+
+    DB::purge('reclaim_test');
+});
+
+test('a colliding table is archived with its data and foreign key names freed', function () {
+    config()->set('habbo.migrations.rename_tables', true);
+
+    $connection = reclaimConnection();
+
+    reclaimSchema()->create('reclaim_parent', function (Blueprint $table) {
+        $table->id();
+    });
+
+    $connection->statement(
+        'CREATE TABLE `reclaim_child` (
+            `id` BIGINT UNSIGNED PRIMARY KEY,
+            `parent_id` BIGINT UNSIGNED,
+            KEY `reclaim_child_parent_id_index` (`parent_id`),
+            CONSTRAINT `reclaim_child_parent_id_foreign` FOREIGN KEY (`parent_id`) REFERENCES `reclaim_parent` (`id`)
+        )',
+    );
+    $connection->table('reclaim_parent')->insert(['id' => 1]);
+    $connection->table('reclaim_child')->insert(['id' => 5, 'parent_id' => 1]);
+
+    reclaimSchema()->create('reclaim_child', function (Blueprint $table) {
+        $table->id();
+        $table->foreignId('parent_id')
+            ->constrained('reclaim_parent');
+    });
+
+    $archived = SchemaReclaimer::prefix() . 'reclaim_child';
+
+    // The new table claimed the name (and the conventional FK name) while
+    // the archive kept its row behind renamed constraints.
+    expect(reclaimSchema()->hasTable('reclaim_child'))->toBeTrue()
+        ->and($connection->table('reclaim_child')->count())->toBe(0)
+        ->and(reclaimSchema()->hasTable($archived))->toBeTrue()
+        ->and($connection->table($archived)->count())->toBe(1);
+
+    $archivedConstraints = collect($connection->select(
+        'SELECT CONSTRAINT_NAME AS name FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_TYPE = ?',
+        [$archived, 'FOREIGN KEY'],
+    ))->pluck('name');
+
+    expect($archivedConstraints)->toHaveCount(1)
+        ->and($archivedConstraints->first())->toStartWith('old_');
+});
+
+test('a colliding column is archived with its data, index and foreign key', function () {
+    config()->set('habbo.migrations.rename_tables', true);
+
+    $connection = reclaimConnection();
+
+    reclaimSchema()->create('reclaim_parent', function (Blueprint $table) {
+        $table->id();
+    });
+
+    $connection->statement(
+        'CREATE TABLE `reclaim_users` (
+            `id` BIGINT UNSIGNED PRIMARY KEY,
+            `parent_id` BIGINT UNSIGNED,
+            `nick` VARCHAR(64),
+            UNIQUE KEY `reclaim_users_nick_unique` (`nick`),
+            KEY `reclaim_users_parent_id_index` (`parent_id`),
+            CONSTRAINT `reclaim_users_parent_id_foreign` FOREIGN KEY (`parent_id`) REFERENCES `reclaim_parent` (`id`)
+        )',
+    );
+    $connection->table('reclaim_parent')->insert(['id' => 1]);
+    $connection->table('reclaim_users')->insert(['id' => 9, 'parent_id' => 1, 'nick' => 'Dennis']);
+
+    reclaimSchema()->table('reclaim_users', function (Blueprint $table) {
+        $table->string('nick', 32)->nullable()->unique();
+        $table->foreignId('parent_id')
+            ->nullable()
+            ->constrained('reclaim_parent');
+    });
+
+    $prefix = SchemaReclaimer::prefix();
+    $columns = reclaimSchema()->getColumnListing('reclaim_users');
+
+    expect($columns)->toContain('nick', 'parent_id', $prefix . 'nick', $prefix . 'parent_id')
+        ->and($connection->table('reclaim_users')->value($prefix . 'nick'))->toBe('Dennis')
+        ->and($connection->table('reclaim_users')->value('nick'))->toBeNull();
+
+    $indexes = collect($connection->select(
+        'SELECT DISTINCT INDEX_NAME AS name FROM information_schema.STATISTICS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?',
+        ['reclaim_users'],
+    ))->pluck('name');
+
+    $constraints = collect($connection->select(
+        'SELECT CONSTRAINT_NAME AS name FROM information_schema.TABLE_CONSTRAINTS
+            WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND CONSTRAINT_TYPE = ?',
+        ['reclaim_users', 'FOREIGN KEY'],
+    ))->pluck('name');
+
+    // The archived column kept its unique index and foreign key under old_
+    // names, while the replacements claimed the conventional ones.
+    expect($indexes)->toContain($prefix . 'reclaim_users_nick_unique')
+        ->and($indexes)->toContain('reclaim_users_nick_unique')
+        ->and($constraints)->toContain($prefix . 'reclaim_users_parent_id_foreign')
+        ->and($constraints)->toContain('reclaim_users_parent_id_foreign');
+});
+
+test('a collision without the rename flag fails with an actionable error', function () {
+    config()->set('habbo.migrations.rename_tables', false);
+
+    reclaimSchema()->create('reclaim_existing', function (Blueprint $table) {
+        $table->id();
+    });
+
+    expect(fn () => reclaimSchema()->create('reclaim_existing', function (Blueprint $table) {
+        $table->id();
+    }))->toThrow(RuntimeException::class, 'RENAME_COLLIDING_TABLES');
+
+    expect(fn () => reclaimSchema()->table('reclaim_existing', function (Blueprint $table) {
+        $table->bigInteger('id');
+    }))->toThrow(RuntimeException::class, 'RENAME_COLLIDING_TABLES');
+
+    // The colliding table was left untouched.
+    expect(reclaimSchema()->hasTable('reclaim_existing'))->toBeTrue();
+});


### PR DESCRIPTION
- Collision-aware mysql/mariadb schema builders move colliding tables and columns aside as old_<timestamp>_<name> when RENAME_COLLIDING_TABLES is on, so migrations need zero inline handling
- Indexes are renamed and foreign keys re-added under prefixed names, freeing the conventional names for the replacement schema while the archived data keeps its constraints
- With the flag off, collisions fail with an actionable message pointing at the flag instead of a raw SQLSTATE error
- Remove the 27 per-migration rename guards
- Cover table, column and flag-off paths against a live MariaDB in SchemaCollisionTest